### PR TITLE
fix: update /usage API to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.4.0)
+    graphql-hive (0.4.1)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/k6/graphql-api/Gemfile.lock
+++ b/k6/graphql-api/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    graphql-hive (0.4.0)
+    graphql-hive (0.4.1)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -39,12 +39,8 @@ module GraphQL
 
       def build_request(uri, path, body)
         request = Net::HTTP::Post.new(uri.request_uri)
-        if path == '/usage'
-          request['Authorization'] = @options[:token]
-          request['X-Usage-API-Version'] = '2'
-        else
-          request['x-api-token'] = @options[:token]
-        end
+        request['Authorization'] = @options[:token]
+        request['X-Usage-API-Version'] = '2'
         request['content-type'] = 'application/json'
         request['User-Agent'] = "Hive@#{Graphql::Hive::VERSION}"
         request['graphql-client-name'] = 'Hive Ruby Client'

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -28,6 +28,7 @@ module GraphQL
         @options[:logger].debug(response.body.inspect)
       rescue StandardError => e
         @options[:logger].fatal("Failed to send data: #{e}")
+        raise e
       end
 
       def setup_http(uri)

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -21,7 +21,7 @@ module GraphQL
           )
 
         http = setup_http(uri)
-        request = build_request(uri, body) 
+        request = build_request(uri, body)
         response = http.request(request)
 
         @options[:logger].debug(response.inspect)
@@ -52,4 +52,3 @@ module GraphQL
     end
   end
 end
-

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -21,7 +21,7 @@ module GraphQL
           )
 
         http = setup_http(uri)
-        request = build_request(uri, path, body) 
+        request = build_request(uri, body) 
         response = http.request(request)
 
         @options[:logger].debug(response.inspect)
@@ -38,7 +38,7 @@ module GraphQL
         http
       end
 
-      def build_request(uri, path, body)
+      def build_request(uri, body)
         request = Net::HTTP::Post.new(uri.request_uri)
         request['Authorization'] = @options[:token]
         request['X-Usage-API-Version'] = '2'

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -128,7 +128,7 @@ module GraphQL
           execution: {
             ok: errors[:errorsTotal].zero?,
             duration: duration,
-            errorsTotal: errors[:errorsTotal],
+            errorsTotal: errors[:errorsTotal]
           }
         }
 
@@ -150,7 +150,7 @@ module GraphQL
         acc = { errorsTotal: 0 }
         results.each do |result|
           errors = result.to_h.fetch('errors', [])
-          errors.each do |error|
+          errors.each do
             acc[:errorsTotal] += 1
           end
         end

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -129,7 +129,6 @@ module GraphQL
             ok: errors[:errorsTotal].zero?,
             duration: duration,
             errorsTotal: errors[:errorsTotal],
-            errors: errors[:errors]
           }
         }
 
@@ -148,12 +147,11 @@ module GraphQL
       end
 
       def errors_from_results(results)
-        acc = { errorsTotal: 0, errors: [] }
+        acc = { errorsTotal: 0 }
         results.each do |result|
           errors = result.to_h.fetch('errors', [])
           errors.each do |error|
             acc[:errorsTotal] += 1
-            acc[:errors] << { message: error['message'], path: error['path']&.join('.') }
           end
         end
         acc

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Hive
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GraphQL::Hive::Client do
+  let(:options) do
+    {
+      endpoint: 'app.graphql-hive.com',
+      port: 443,
+      token: 'Bearer test-token',
+      logger: Logger.new(nil)
+    }
+  end
+
+  let(:client) { described_class.new(options) }
+  let(:body) { { size: 3, map: {}, operations: [] } }
+
+  describe '#initialize' do
+    it 'sets the instance' do
+        expect(client.instance_variable_get(:@options)).to eq(options)
+    end
+  end
+
+  describe "#send" do
+    let(:http) { instance_double(Net::HTTP) }
+    let(:request) { instance_double(Net::HTTP::Post) }
+    let(:response) { instance_double(Net::HTTPOK, body: '', code: '200') }
+
+    before do
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(Net::HTTP::Post).to receive(:new).and_return(request)
+
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:request).and_return(response)
+
+      allow(request).to receive(:[]=) # request['header-name'] = 'header-value'
+      allow(request).to receive(:body=)
+    end
+
+    context "when the path is '/usage'" do
+      it "sets the Authorization and X-Usage-API-Version headers" do
+        expect(request).to receive(:[]=).with('Authorization', 'Bearer test-token')
+        expect(request).to receive(:[]=).with('X-Usage-API-Version', '2')
+        
+        client.send('/usage', body, :usage)
+      end
+    end
+
+    context "when the path is not '/usage'" do
+      it "sets the x-api-token header" do
+        expect(request).to receive(:[]=).with('x-api-token', 'Bearer test-token')
+
+        client.send('/registry', body, :'report-schema')
+      end
+    end
+
+    context "when an exception is raised" do
+      it "logs a fatal error" do
+        allow(http).to receive(:request).and_raise(StandardError.new("Network error"))
+        expect(options[:logger]).to receive(:fatal).with("Failed to send data: Network error")
+
+        client.send('/usage', body, :usage)
+      end
+    end
+  end
+end

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe GraphQL::Hive::Client do
 
   describe '#initialize' do
     it 'sets the instance' do
-        expect(client.instance_variable_get(:@options)).to eq(options)
+      expect(client.instance_variable_get(:@options)).to eq(options)
     end
   end
 

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -65,11 +65,10 @@ RSpec.describe GraphQL::Hive::Client do
       client.send('/usage', body, :usage)
     end
 
-    it "logs a fatal error when an exception is raised" do
+    it "logs a fatal error and raises an exception when an exception is raised" do
       allow(http).to receive(:request).and_raise(StandardError.new("Network error"))
       expect(options[:logger]).to receive(:fatal).with("Failed to send data: Network error")
-
-      client.send('/usage', body, :usage)
+      expect { client.send('/usage', body, :usage) }.to raise_error(StandardError, "Network error")
     end
   end
 end

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GraphQL::Hive::Client do
     end
   end
 
-  describe "#send" do
+  describe '#send' do
     let(:http) { instance_double(Net::HTTP) }
     let(:request) { instance_double(Net::HTTP::Post) }
     let(:response) { instance_double(Net::HTTPOK, body: '', code: '200') }
@@ -39,7 +39,7 @@ RSpec.describe GraphQL::Hive::Client do
       allow(request).to receive(:body=)
     end
 
-    it "sets up the HTTP session" do
+    it 'sets up the HTTP session' do
       expect(Net::HTTP).to receive(:new).with('app.graphql-hive.com', 443).and_return(http)
       expect(http).to receive(:use_ssl=).with(true)
       expect(http).to receive(:read_timeout=).with(2)
@@ -47,7 +47,7 @@ RSpec.describe GraphQL::Hive::Client do
       client.send('/usage', body, :usage)
     end
 
-    it "creates the request with the correct headers and body" do
+    it 'creates the request with the correct headers and body' do
       expect(Net::HTTP::Post).to receive(:new).with('/usage').and_return(request)
       expect(request).to receive(:[]=).with('Authorization', 'Bearer test-token')
       expect(request).to receive(:[]=).with('X-Usage-API-Version', '2')
@@ -60,15 +60,15 @@ RSpec.describe GraphQL::Hive::Client do
       client.send('/usage', body, :usage)
     end
 
-    it "executes the request" do
+    it 'executes the request' do
       expect(http).to receive(:request).with(request).and_return(response)
       client.send('/usage', body, :usage)
     end
 
-    it "logs a fatal error and raises an exception when an exception is raised" do
-      allow(http).to receive(:request).and_raise(StandardError.new("Network error"))
-      expect(options[:logger]).to receive(:fatal).with("Failed to send data: Network error")
-      expect { client.send('/usage', body, :usage) }.to raise_error(StandardError, "Network error")
+    it 'logs a fatal error and raises an exception when an exception is raised' do
+      allow(http).to receive(:request).and_raise(StandardError.new('Network error'))
+      expect(options[:logger]).to receive(:fatal).with('Failed to send data: Network error')
+      expect { client.send('/usage', body, :usage) }.to raise_error(StandardError, 'Network error')
     end
   end
 end

--- a/spec/graphql/graphql-hive/usage_reporter_spec.rb
+++ b/spec/graphql/graphql-hive/usage_reporter_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe GraphQL::Hive::UsageReporter do
             } },
           operations: [
             {
-              execution: { duration: 100_000, errors: [], errorsTotal: 0, ok: true },
+              execution: { duration: 100_000, errorsTotal: 0, ok: true },
               operationMapKey: '8b8412ce86f3ea7accb931b1a5de335d',
               timestamp: 1_720_705_946_333
             }


### PR DESCRIPTION
## Context
`graphql-ruby-hive` is not using the latest version of the endpoint for reporting usage. We want to use the endpoint for `/usage` exactly as described in their documentation here: [Usage Reporting (Hive)](https://the-guild.dev/graphql/hive/docs/specs/usage-reports)

## Changes
- Set `Authorization` and `X-Usage-API-Version` headers 
- Removed `errors` in `operation_record` in UsageReporter (removed in latest version)
- Refactored `Client` class to improve readability 

## Testing
- Unit tests (UsageReporter and Client)