### PR TITLE
fix(client): do not raise error again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.4.1)
+    graphql-hive (0.4.2)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/k6/graphql-api/Gemfile.lock
+++ b/k6/graphql-api/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    graphql-hive (0.4.1)
+    graphql-hive (0.4.2)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -28,7 +28,6 @@ module GraphQL
         @options[:logger].debug(response.body.inspect)
       rescue StandardError => e
         @options[:logger].fatal("Failed to send data: #{e}")
-        raise e
       end
 
       def setup_http(uri)

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -71,10 +71,7 @@ module GraphQL
         rescue StandardError => e
           # ensure configured logger receives exception as well in setups where STDERR might not be
           # monitored.
-          @options[:logger].error('GraphQL Hive usage collection thread terminating')
           @options[:logger].error(e)
-
-          raise e
         end
       end
 

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Hive
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe GraphQL::Hive::Client do
       client.send('/usage', body, :usage)
     end
 
-    it 'logs a fatal error and raises an exception when an exception is raised' do
+    it 'logs a fatal error when an exception is raised' do
       allow(http).to receive(:request).and_raise(StandardError.new('Network error'))
       expect(options[:logger]).to receive(:fatal).with('Failed to send data: Network error')
-      expect { client.send('/usage', body, :usage) }.to raise_error(StandardError, 'Network error')
+      expect { client.send('/usage', body, :usage) }.not_to raise_error(StandardError, 'Network error')
     end
   end
 end


### PR DESCRIPTION
Fixes: #30 

Will not raise error and will allow thread to continue processing. This fix is scoped only to the case where we timeout in the connection to Hive. I will follow up with a PR that handles thread restarts and other errors correctly.