### PR TITLE
fix: update version to correct semantic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.5.3)
+    graphql-hive (0.5.0)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/k6/graphql-api/Gemfile.lock
+++ b/k6/graphql-api/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    graphql-hive (0.5.3)
+    graphql-hive (0.5.0)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Hive
-    VERSION = "0.5.3"
+    VERSION = "0.5.0"
   end
 end


### PR DESCRIPTION
The last PR updated to `0.5.3` instead of `0.5.0`.