### PR TITLE
fix: exclude invalid fields in analyzer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.5.1)
+    graphql-hive (0.5.2)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -10,8 +10,11 @@ module GraphQL
       end
 
       def on_enter_field(node, _parent, visitor)
-        @used_fields.add(visitor.parent_type_definition.graphql_name)
-        @used_fields.add(make_id(visitor.parent_type_definition.graphql_name, node.name))
+        parent_type = visitor.parent_type_definition
+        if parent_type&.respond_to?(:graphql_name) && parent_type.fields[node.name]
+          @used_fields.add(parent_type.graphql_name)
+          @used_fields.add(make_id(parent_type.graphql_name, node.name))
+        end
       end
 
       # Visitor also calls 'on_enter_argument' when visiting input object fields in arguments

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -24,10 +24,6 @@ module GraphQL
         request = build_request(uri, body)
         response = http.request(request)
 
-        if response.code.to_i >= 400 && response.code.to_i < 500
-          @options[:logger].warn("Unsuccessful response: #{response.code} - #{response.body}")
-        end
-
         @options[:logger].debug(response.inspect)
         @options[:logger].debug(response.body.inspect)
       rescue => e

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -24,6 +24,10 @@ module GraphQL
         request = build_request(uri, body)
         response = http.request(request)
 
+        if response.code.to_i != 200
+          @options[:logger].warn("Unsuccessful response: #{response.code} - #{response.body}")
+        end
+
         @options[:logger].debug(response.inspect)
         @options[:logger].debug(response.body.inspect)
       rescue => e

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -24,7 +24,7 @@ module GraphQL
         request = build_request(uri, body)
         response = http.request(request)
 
-        if response.code.to_i != 200
+        if response.code.to_i >= 400 && response.code.to_i < 500
           @options[:logger].warn("Unsuccessful response: #{response.code} - #{response.body}")
         end
 

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Hive
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -361,21 +361,21 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
       }
       |
     end
-    
+
     it "collects all valid fields and excludes invalid fields" do
       expect(used_fields).to include(
         "Query",
         "Query.projectsByManyTypes",
         "ProjectType",
         "Query.projectsByManyTypes.type",
-        "ProjectType.STITCHING",
+        "ProjectType.STITCHING"
       )
       expect(used_fields).not_to include(
-        "Query.nonExistentField", 
+        "Query.nonExistentField",
         "nonExistentField.subField"
       )
     end
-  
+
     it "does not raise an error when encountering an invalid field" do
       expect { used_fields }.not_to raise_error
     end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -352,32 +352,24 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
 
   context "with an invalid field" do
     let(:query_string) do
-      %|
+      <<~GQL
       query getGatewayProjects {
         projectsByManyTypes(type: [STITCHING]),
         nonExistentField {
           subField
         }
       }
-      |
+      GQL
     end
 
     it "collects all valid fields and excludes invalid fields" do
-      expect(used_fields).to include(
+      expect(used_fields).to contain_exactly(
         "Query",
         "Query.projectsByManyTypes",
         "ProjectType",
         "Query.projectsByManyTypes.type",
         "ProjectType.STITCHING"
       )
-      expect(used_fields).not_to include(
-        "Query.nonExistentField",
-        "nonExistentField.subField"
-      )
-    end
-
-    it "does not raise an error when encountering an invalid field" do
-      expect { used_fields }.not_to raise_error
     end
   end
 end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -353,12 +353,12 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
   context "with an invalid field" do
     let(:query_string) do
       <<~GQL
-      query getGatewayProjects {
-        projectsByManyTypes(type: [STITCHING]),
-        nonExistentField {
-          subField
+        query getGatewayProjects {
+          projectsByManyTypes(type: [STITCHING]),
+          nonExistentField {
+            subField
+          }
         }
-      }
       GQL
     end
 

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -349,4 +349,35 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
       )
     end
   end
+
+  context "with an invalid field" do
+    let(:query_string) do
+      %|
+      query getGatewayProjects {
+        projectsByManyTypes(type: [STITCHING]),
+        nonExistentField {
+          subField
+        }
+      }
+      |
+    end
+    
+    it "collects all valid fields and excludes invalid fields" do
+      expect(used_fields).to include(
+        "Query",
+        "Query.projectsByManyTypes",
+        "ProjectType",
+        "Query.projectsByManyTypes.type",
+        "ProjectType.STITCHING",
+      )
+      expect(used_fields).not_to include(
+        "Query.nonExistentField", 
+        "nonExistentField.subField"
+      )
+    end
+  
+    it "does not raise an error when encountering an invalid field" do
+      expect { used_fields }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Context
When encountering invalid fields in a query, the analyzer would throw an error: 
```
undefined method 'graphql_name' for nil (NoMethodError)
```

We want to handle these cases gracefully. 

## Changes
- Updated the `on_enter_field` method in the `GraphQL::Hive::Analyzer` to  validate both the parent type and the field existence before adding to `@used_fields`.

## Testing
- Unit test (Analyzer)