### PR TITLE
fix: remove `parent_type.fields` check in analyzer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.5.2)
+    graphql-hive (0.5.3)
       graphql (>= 2.3, < 3)
 
 GEM

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -11,7 +11,7 @@ module GraphQL
 
       def on_enter_field(node, _parent, visitor)
         parent_type = visitor.parent_type_definition
-        if parent_type&.respond_to?(:graphql_name)
+        if parent_type&.respond_to?(:graphql_name) && node&.respond_to?(:name)
           @used_fields.add(parent_type.graphql_name)
           @used_fields.add(make_id(parent_type.graphql_name, node.name))
         end

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -11,7 +11,7 @@ module GraphQL
 
       def on_enter_field(node, _parent, visitor)
         parent_type = visitor.parent_type_definition
-        if parent_type&.respond_to?(:graphql_name) && parent_type.fields[node.name]
+        if parent_type&.respond_to?(:graphql_name)
           @used_fields.add(parent_type.graphql_name)
           @used_fields.add(make_id(parent_type.graphql_name, node.name))
         end

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,6 +2,6 @@
 
 module Graphql
   module Hive
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
         "Query",
         "Query.searchResult",
         "Query.searchResult.query",
-        "SearchResult", 
+        "SearchResult",
         "SearchResult.__typename",
         "Project",
         "Project.id",

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
         "Query",
         "Query.searchResult",
         "Query.searchResult.query",
-        "SearchResult", 
+        "SearchResult",
         "SearchResult.nonExistentField",
         "Project",
         "Project.id",

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -16,70 +16,75 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
   end
 
   let(:schema) do
-    GraphQL::Schema.from_definition(%|
-      type Query {
-        project(selector: ProjectSelectorInput!): Project
-        projectsByType(type: ProjectType!): [Project!]!
-        projectsByManyTypes(type: [ProjectType!]!): [Project!]!
-        projects(filter: FilterInput): [Project!]!
-      }
+    GraphQL::Schema.from_definition(
+      <<~GQL
+        type Query {
+          project(selector: ProjectSelectorInput!): Project
+          projectsByType(type: ProjectType!): [Project!]!
+          projectsByManyTypes(type: [ProjectType!]!): [Project!]!
+          projects(filter: FilterInput): [Project!]!
+          searchResult(query: String!): SearchResult
+        }
 
-      type Mutation {
-        deleteProject(selector: ProjectSelectorInput!): DeleteProjectPayload!
-      }
+        type Mutation {
+          deleteProject(selector: ProjectSelectorInput!): DeleteProjectPayload!
+        }
 
-      input ProjectSelectorInput {
-        organization: ID!
-        project: ID!
-      }
+        input ProjectSelectorInput {
+          organization: ID!
+          project: ID!
+        }
 
-      input FilterInput {
-        type: ProjectType
-        pagination: PaginationInput
-        order: [ProjectOrderByInput!]
-      }
+        input FilterInput {
+          type: ProjectType
+          pagination: PaginationInput
+          order: [ProjectOrderByInput!]
+        }
 
-      input PaginationInput {
-        limit: Int
-        offset: Int
-      }
+        input PaginationInput {
+          limit: Int
+          offset: Int
+        }
 
-      input ProjectOrderByInput {
-        field: String!
-        direction: OrderDirection
-      }
+        input ProjectOrderByInput {
+          field: String!
+          direction: OrderDirection
+        }
 
-      enum OrderDirection {
-        ASC
-        DESC
-      }
+        enum OrderDirection {
+          ASC
+          DESC
+        }
 
-      type ProjectSelector {
-        organization: ID!
-        project: ID!
-      }
+        type ProjectSelector {
+          organization: ID!
+          project: ID!
+        }
 
-      type DeleteProjectPayload {
-        selector: ProjectSelector!
-        deletedProject: Project!
-      }
+        type DeleteProjectPayload {
+          selector: ProjectSelector!
+          deletedProject: Project!
+        }
 
-      type Project {
-        id: ID!
-        cleanId: ID!
-        name: String!
-        type: ProjectType!
-        buildUrl: String
-        validationUrl: String
-      }
+        type Project {
+          id: ID!
+          cleanId: ID!
+          name: String!
+          type: ProjectType!
+          buildUrl: String
+          validationUrl: String
+        }
 
-      enum ProjectType {
-        FEDERATION
-        STITCHING
-        SINGLE
-        CUSTOM
-      }
-    |)
+        enum ProjectType {
+          FEDERATION
+          STITCHING
+          SINGLE
+          CUSTOM
+        }
+
+        union SearchResult = Project | ProjectSelector
+      GQL
+    )
   end
 
   let(:query_string) do
@@ -350,11 +355,21 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
     end
   end
 
-  context "with an invalid field" do
+  context "with invalid fields" do
     let(:query_string) do
       <<~GQL
         query getGatewayProjects {
-          projectsByManyTypes(type: [STITCHING]),
+          searchResult(query: $query) {
+            nonExistentField {
+              subField
+            }
+            ... on Project {
+              id
+            }
+            ... on ProjectSelector {
+              organization
+            }
+          }
           nonExistentField {
             subField
           }
@@ -365,10 +380,16 @@ RSpec.describe "GraphQL::Hive::Analyzer" do
     it "collects all valid fields and excludes invalid fields" do
       expect(used_fields).to contain_exactly(
         "Query",
-        "Query.projectsByManyTypes",
-        "ProjectType",
-        "Query.projectsByManyTypes.type",
-        "ProjectType.STITCHING"
+        "Query.searchResult",
+        "Query.searchResult.query",
+        "SearchResult", 
+        "SearchResult.nonExistentField",
+        "Project",
+        "Project.id",
+        "ProjectSelector",
+        "ProjectSelector.organization",
+        "Query.nonExistentField",
+        "String"
       )
     end
   end


### PR DESCRIPTION
## Context
Follow-up to https://github.com/rperryng/graphql-ruby-hive/pull/44

For direct fields in Union types, for example, `__typename` in 
```
query {
  searchResult(query: $query) {
    __typename
    ... on Project {
      id
    }
  }
}
```
the `parent_type.fields[node.name]` check results in 
```
undefined method `fields' for class [UnionType] (NoMethodError)
```

## Changes
- Update `parent_type.fields` check to be `node&.respond_to?(:name)`

## Testing
- Unit test (Analyzer)

