### PR TITLE
refactor(graphql-hive.rb): clean up file, move config to class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Refactored graphql-hive.rb to us a configuration class
+- Refactored graphql-hive.rb to use a separate class for sending the schema to the registry

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -118,3 +118,7 @@ module GraphQL
     end
   end
 end
+
+at_exit do
+  GraphQL::Hive.instance&.on_exit
+end

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -14,9 +14,9 @@ module GraphQL
       def send(path, body, _log_type)
         uri =
           URI::HTTP.build(
-            scheme: (@options[:port].to_s == "443") ? "https" : "http",
-            host: @options[:endpoint] || "app.graphql-hive.com",
-            port: @options[:port] || "443",
+            scheme: (@options.port.to_s == "443") ? "https" : "http",
+            host: @options.endpoint,
+            port: @options.port,
             path: path
           )
 
@@ -24,22 +24,22 @@ module GraphQL
         request = build_request(uri, body)
         response = http.request(request)
 
-        @options[:logger].debug(response.inspect)
-        @options[:logger].debug(response.body.inspect)
+        @options.logger.debug(response.inspect)
+        @options.logger.debug(response.body.inspect)
       rescue => e
-        @options[:logger].fatal("Failed to send data: #{e}")
+        @options.logger.fatal("Failed to send data: #{e}")
       end
 
       def setup_http(uri)
         http = ::Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = @options[:port].to_s == "443"
+        http.use_ssl = @options.port.to_s == "443"
         http.read_timeout = 2
         http
       end
 
       def build_request(uri, body)
         request = Net::HTTP::Post.new(uri.request_uri)
-        request["Authorization"] = @options[:token]
+        request["Authorization"] = @options.token
         request["X-Usage-API-Version"] = "2"
         request["content-type"] = "application/json"
         request["User-Agent"] = "Hive@#{Graphql::Hive::VERSION}"

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -31,8 +31,9 @@ module GraphQL
 
       def validate!
         if !@token && @enabled
-          @logger.warn("GraphQL Hive `token` is missing. Disabling Usage Reporting.")
+          @logger.warn("GraphQL Hive `token` is missing. Disabling Reporting.")
           @enabled = false
+          @report_schema = false
         end
         if @report_schema && (@reporting.dig(:author) || !@reporting.dig(:commit))
           @logger.warn("GraphQL Hive `author` and `commit` options are required. Disabling Schema Reporting.")

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -1,0 +1,58 @@
+module GraphQL
+  # GraphQL Hive usage collector and schema reporter
+  class Hive < GraphQL::Tracing::PlatformTracing
+    class Configuration
+      attr_accessor :buffer_size, :client_info, :collect_usage, :collect_usage_sampling, :debug, :enabled, :endpoint, :logger, :port, :queue_size, :read_operations, :report_schema, :reporting, :token
+
+      DEFAULT_OPTIONS = {
+        buffer_size: 50,
+        client_info: nil,
+        collect_usage: true,
+        collect_usage_sampling: 1.0,
+        debug: false,
+        enabled: true,
+        endpoint: "app.graphql-hive.com",
+        logger: nil,
+        port: "443",
+        queue_size: 1000,
+        read_operations: true,
+        report_schema: true,
+        reporting: {author: nil, commit: nil, service_name: nil, service_url: nil},
+        token: nil
+      }.freeze
+
+      def initialize(opts = {})
+        DEFAULT_OPTIONS.merge(opts).each do |key, value|
+          instance_variable_set(:"@#{key}", value)
+        end
+        setup_logger if @logger.nil?
+        validate!
+      end
+
+      def validate!
+        if !@token && @enabled
+          @logger.warn("GraphQL Hive `token` is missing. Disabling Usage Reporting.")
+          @enabled = false
+        end
+        if @report_schema && (@reporting.dig(:author) || !@reporting.dig(:commit))
+          @logger.warn("GraphQL Hive `author` and `commit` options are required. Disabling Schema Reporting.")
+          @report_schema = false
+        end
+      end
+
+      private
+
+      def setup_logger
+        @logger = Logger.new($stderr)
+        original_formatter = Logger::Formatter.new
+
+        @logger.formatter = proc { |severity, datetime, progname, msg|
+          msg = msg.respond_to?(:dump) ? msg.dump : msg
+          original_formatter.call(severity, datetime, progname, "[hive] #{msg}")
+        }
+
+        @logger.level = @debug ? Logger::DEBUG : Logger::INFO
+      end
+    end
+  end
+end

--- a/lib/graphql-hive/schema_reporter.rb
+++ b/lib/graphql-hive/schema_reporter.rb
@@ -1,0 +1,34 @@
+class GraphQL::Hive::SchemaReporter
+  REPORT_SCHEMA_MUTATION = <<~MUTATION
+    mutation schemaPublish($input: SchemaPublishInput!) {
+      schemaPublish(input: $input) {
+        __typename
+      }
+    }
+  MUTATION
+
+  def initialize(sdl, client, reporting_options)
+    @sdl = sdl
+    @client = client
+    @reporting_options = reporting_options
+  end
+
+  def send_report
+    body = {
+      query: REPORT_SCHEMA_MUTATION,
+      operationName: "schemaPublish",
+      variables: {
+        input: {
+          sdl: @sdl,
+          author: @reporting_options[:author],
+          commit: @reporting_options[:commit],
+          service: @reporting_options[:service_name],
+          url: @reporting_options[:service_url],
+          force: true
+        }
+      }
+    }
+
+    @client.send(:"/registry", body, :"report-schema")
+  end
+end

--- a/spec/graphql/graphql-hive/client_spec.rb
+++ b/spec/graphql/graphql-hive/client_spec.rb
@@ -5,12 +5,12 @@ require "graphql-hive"
 
 RSpec.describe GraphQL::Hive::Client do
   let(:options) do
-    {
+    GraphQL::Hive::Configuration.new({
       endpoint: "app.graphql-hive.com",
       port: 443,
       token: "Bearer test-token",
       logger: Logger.new(nil)
-    }
+    })
   end
 
   let(:client) { described_class.new(options) }
@@ -67,7 +67,7 @@ RSpec.describe GraphQL::Hive::Client do
 
     it "logs a fatal error when an exception is raised" do
       allow(http).to receive(:request).and_raise(StandardError.new("Network error"))
-      expect(options[:logger]).to receive(:fatal).with("Failed to send data: Network error")
+      expect(options.logger).to receive(:fatal).with("Failed to send data: Network error")
       expect { client.send(:"/usage", body, :usage) }.not_to raise_error(StandardError, "Network error")
     end
   end

--- a/spec/graphql/graphql-hive/configuration_spec.rb
+++ b/spec/graphql/graphql-hive/configuration_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe GraphQL::Hive::Configuration do
       subject(:config) { described_class.new(logger: logger) }
       it "disables the service and logs a warning" do
         expect(config.enabled).to be false
+        expect(config.report_schema).to be false
         expect(logger).to have_received(:warn).with(/token.*missing/)
       end
     end

--- a/spec/graphql/graphql-hive/configuration_spec.rb
+++ b/spec/graphql/graphql-hive/configuration_spec.rb
@@ -1,0 +1,101 @@
+require "spec_helper"
+require "logger"
+
+RSpec.describe GraphQL::Hive::Configuration do
+  let(:valid_options) do
+    {
+      token: "test-token",
+      report_schema: true,
+      reporting: {
+        author: "test-author",
+        commit: "test-commit"
+      }
+    }
+  end
+
+  describe "#initialize" do
+    context "with default options" do
+      subject(:config) { described_class.new }
+
+      it "sets default values" do
+        expect(config.buffer_size).to eq(50)
+        expect(config.collect_usage).to be true
+        expect(config.collect_usage_sampling).to eq(1.0)
+        expect(config.debug).to be false
+        expect(config.enabled).to be false # disabled due to missing token
+        expect(config.endpoint).to eq("app.graphql-hive.com")
+        expect(config.port).to eq("443")
+        expect(config.queue_size).to eq(1000)
+        expect(config.read_operations).to be true
+        expect(config.report_schema).to be false # disabled due to missing reporting info
+      end
+
+      it "creates a logger with correct settings" do
+        expect(config.logger).to be_a(Logger)
+        expect(config.logger.level).to eq(Logger::INFO)
+      end
+
+      context "when debug is enabled" do
+        subject(:config) { described_class.new(debug: true) }
+
+        it "sets logger level to DEBUG" do
+          expect(config.logger.level).to eq(Logger::DEBUG)
+        end
+      end
+
+      it "configures custom formatter" do
+        # Test the formatter by capturing output
+        output = StringIO.new
+        config.logger.instance_variable_set(:@logdev, Logger::LogDevice.new(output))
+        config.logger.info("test message")
+
+        expect(output.string).to include("[hive]")
+        expect(output.string).to include("test message")
+      end
+    end
+
+    context "with custom options" do
+      subject(:config) { described_class.new(valid_options) }
+
+      it "merges custom options with defaults" do
+        expect(config.token).to eq("test-token")
+        expect(config.reporting).to include(
+          author: "test-author",
+          commit: "test-commit"
+        )
+      end
+    end
+  end
+
+  describe "#validate!" do
+    let(:logger) { instance_double(Logger) }
+
+    before { allow(logger).to receive(:warn) }
+
+    context "when token is missing" do
+      subject(:config) { described_class.new(logger: logger) }
+      it "disables the service and logs a warning" do
+        expect(config.enabled).to be false
+        expect(logger).to have_received(:warn).with(/token.*missing/)
+      end
+    end
+
+    context "when reporting info is incomplete" do
+      subject(:config) { described_class.new(token: "test-token", logger: logger) }
+
+      it "disables schema reporting and logs a warning" do
+        expect(config.report_schema).to be false
+        expect(logger).to have_received(:warn).with(/author.*commit.*required/)
+      end
+    end
+
+    context "with valid configuration" do
+      subject(:config) { described_class.new(valid_options) }
+
+      it "keeps the service enabled" do
+        expect(config.enabled).to be true
+        expect(logger).not_to have_received(:warn)
+      end
+    end
+  end
+end

--- a/spec/graphql/graphql-hive/schema_reporter_spec.rb
+++ b/spec/graphql/graphql-hive/schema_reporter_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe GraphQL::Hive::SchemaReporter do
+  let(:sdl) { "type Query { hello: String }" }
+  let(:client) { instance_double("GraphQL::Hive::Client") }
+  let(:reporting_options) do
+    {
+      author: "test_author",
+      commit: "abc123",
+      service_name: "test_service",
+      service_url: "http://example.com"
+    }
+  end
+
+  subject { described_class.new(sdl, client, reporting_options) }
+
+  describe "#initialize" do
+    it "sets the instance variables correctly" do
+      expect(subject.instance_variable_get(:@sdl)).to eq(sdl)
+      expect(subject.instance_variable_get(:@client)).to eq(client)
+      expect(subject.instance_variable_get(:@reporting_options)).to eq(reporting_options)
+    end
+  end
+
+  describe "#send_report" do
+    it "sends the correct mutation to the client" do
+      expected_body = {
+        query: described_class::REPORT_SCHEMA_MUTATION,
+        operationName: "schemaPublish",
+        variables: {
+          input: {
+            sdl: sdl,
+            author: reporting_options[:author],
+            commit: reporting_options[:commit],
+            service: reporting_options[:service_name],
+            url: reporting_options[:service_url],
+            force: true
+          }
+        }
+      }
+
+      allow(client).to receive(:send)
+
+      subject.send_report
+
+      expect(client).to have_received(:send)
+        .with(:"/registry", expected_body, :"report-schema")
+        .once
+    end
+  end
+end

--- a/spec/graphql/graphql-hive/usage_reporter_spec.rb
+++ b/spec/graphql/graphql-hive/usage_reporter_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe GraphQL::Hive::UsageReporter do
   let(:usage_reporter_instance) { described_class.new(options, client) }
-  let(:options) { {logger: logger, buffer_size: buffer_size, queue_size: 1000} }
+  let(:options) { GraphQL::Hive::Configuration.new({logger: logger, buffer_size: buffer_size, queue_size: 1000}) }
   let(:logger) { instance_double("Logger") }
   let(:client) { instance_double("Hive::Client") }
   let(:buffer_size) { 1 }
@@ -46,13 +46,19 @@ RSpec.describe GraphQL::Hive::UsageReporter do
     end
 
     describe "when the queue is full" do
-      let(:options) { {logger: logger, buffer_size: 1, queue_size: 1} }
+      let(:options) do
+        GraphQL::Hive::Configuration.new({
+          logger: logger,
+          buffer_size: 1,
+          queue_size: 1
+        })
+      end
 
       it "logs an error" do
         allow(logger).to receive(:error)
         usage_reporter_instance.add_operation("operation 1")
         usage_reporter_instance.add_operation("operation 2")
-        expect(logger).to have_received(:error)
+        expect(logger).to have_received(:error).with("SizedQueue is full, discarding operation. Size: 1, Max: 1")
       end
     end
   end
@@ -89,11 +95,11 @@ RSpec.describe GraphQL::Hive::UsageReporter do
 
     context "when configured with sampling" do
       let(:options) do
-        {
+        GraphQL::Hive::Configuration.new({
           logger: logger,
           buffer_size: 1,
           queue_size: 1000
-        }
+        })
       end
 
       let(:sampler_class) { class_double(GraphQL::Hive::Sampler).as_stubbed_const }


### PR DESCRIPTION
This is a refactor of graphql-hive.rb that moves configuration information to a `Configuration` class. Later, this will allow us to configure GraphQL Hive outside of a schema.rb file.