### PR TITLE
Support `trace_with`, resolve namespace conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Works with `Schema.trace_with` you will need to update your schema to use this method. There is an example in app.rb
+
+### Removed
+- No longer works with `Schema.use` as this is deprecated in graphql-ruby.
+- Namespace conflict with `GraphQL`. Everything is now named `GraphQLHive`.
+
 ### Changed
 - Refactored graphql-hive.rb to us a configuration class
 - Refactored graphql-hive.rb to use a separate class for sending the schema to the registry
@@ -16,3 +23,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Processor to run the loop
 - Broke UsageReporter into smaller classes
 - Add `start` and `stop` methods for clarity that they don't accept a block
+- Only start reporter if it is needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - No longer works with `Schema.use` as this is deprecated in graphql-ruby.
 - Namespace conflict with `GraphQL`. Everything is now named `GraphQLHive`.
+- Support for Ruby 3.1 as it will reach EOL in March 2025.
 
 ### Changed
 - Refactored graphql-hive.rb to us a configuration class

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ gem install graphql-hive
 
 <br/>
 
-## 2. Configure `GraphQL::Hive` in your Schema
+## 2. Configure `GraphQLHive` in your Schema
 
-Add `GraphQL::Hive` **at the end** of your schema definition:
+Add `GraphQLHive` **at the end** of your schema definition:
 
 ```ruby
 class Schema < GraphQL::Schema
   query QueryType
 
-  use(
-      GraphQL::Hive,
+  trace_with(
+      GraphQLHive::Tracer,
       {
         token: '<YOUR_TOKEN>',
         reporting: {
@@ -71,7 +71,7 @@ them at all!
 
 ### `start`
 
-Call this hook if you are running `GraphQL::Hive` in a process that `fork`s
+Call this hook if you are running `GraphQLHive` in a process that `fork`s
 itself.
 
 example: `puma` web server running in (["clustered
@@ -82,7 +82,7 @@ mode"](https://github.com/puma/puma/tree/6d8b728b42a61bcf3c1e4c698c9165a45e6071e
 preload_app!
 
 on_worker_boot do
-  GraphQL::Hive.instance.start
+  GraphQLHive.instance.start
 end
 ```
 
@@ -97,7 +97,7 @@ to call into, call `on_worker_exit`.
 # config/puma.rb
 
 on_worker_shutdown do
-  GraphQL::Hive.instance.on_exit
+  GraphQLHive.instance.on_exit
 end
 ```
 
@@ -139,12 +139,12 @@ https://docs.graphql-hive.com/features/integrations#github
 
 # Configuration
 
-You will find below the complete list of options of `GraphQL::Hive`:
+You will find below the complete list of options of `GraphQLHive`:
 
 ```ruby
 class MySchema < GraphQL::Schema
-  use(
-    GraphQL::Hive,
+  trace_with(
+    GraphQLHive::Trace,
     {
       # Token is the only required configuration value.
       token: 'YOUR-REGISTRY-TOKEN',

--- a/graphql-hive.gemspec
+++ b/graphql-hive.gemspec
@@ -6,7 +6,7 @@ require "graphql-hive/version"
 
 Gem::Specification.new do |spec|
   spec.name = "graphql-hive"
-  spec.version = Graphql::Hive::VERSION
+  spec.version = GraphQLHive::VERSION
   spec.authors = ["Charly POLY"]
   spec.email = ["cpoly55@gmail.com"]
 

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -15,92 +15,70 @@ require "graphql-hive/schema_reporter"
 require "graphql-hive/configuration"
 require "graphql"
 
-module GraphQL
-  # GraphQL Hive usage collector and schema reporter
-  class Hive < GraphQL::Tracing::PlatformTracing
-    @@schema = nil
-    @@instance = nil
-
-    self.platform_keys = {
-      "lex" => "lex",
-      "parse" => "parse",
-      "validate" => "validate",
-      "analyze_query" => "analyze_query",
-      "analyze_multiplex" => "analyze_multiplex",
-      "execute_multiplex" => "execute_multiplex",
-      "execute_query" => "execute_query",
-      "execute_query_lazy" => "execute_query_lazy"
-    }
-
-    def initialize(options = {})
-      @configuration = GraphQL::Hive::Configuration.new(options)
-      super
-      @@instance = self
-      @client = GraphQL::Hive::Client.new(@configuration)
-      report_schema_to_hive if @@schema && @configuration.report_schema
-    end
-
-    def self.instance
-      @@instance
-    end
-
-    def self.use(schema, **kwargs)
-      @@schema = schema
+module GraphQLHive
+  module Trace
+    def initialize(multiplex: nil, query: nil, **options)
+      # TODO make configuration a singleton
+      @configuration = GraphQLHive::Configuration.new(options)
+      GraphQLHive::Tracing.instance.configuration = @configuration
+      @tracer = GraphQLHive::Tracing.instance
+      # TODO put in configuration so we don't call this on every trace
+      report_schema_to_hive(options[:schema])
       super
     end
 
-    # called on trace events
-    def platform_trace(platform_key, _key, data)
-      return yield unless should_collect_usage?
-      return yield unless platform_key == "execute_multiplex"
-      return yield unless data[:multiplex]
+    def execute_multiplex(multiplex:)
+      return super unless should_collect_usage?
 
-      queries = data[:multiplex].queries
-      return yield if queries.empty?
-
-      timestamp = generate_timestamp
-      results, duration = measure_execution { yield }
-
-      usage_reporter.add_operation([timestamp, queries, results, duration])
-      results
-    rescue => e
-      @configuration.logger.error(e)
-      yield
+      @tracer.trace(resource: multiplex.queries.first.to_s, queries: multiplex.queries) do
+        super
+      end
     end
 
     def should_collect_usage?
-      @configuration.enabled && @configuration.collect_usage
+      @configuration.enabled? && @configuration.collect_usage?
     end
 
-    def generate_timestamp
-      (Time.now.utc.to_f * 1000).to_i
+    def report_schema_to_hive(schema)
+      return if schema.nil? || !@configuration.report_schema
+
+      sdl = GraphQL::Schema::Printer.new(schema).print_schema
+      SchemaReporter.new(sdl, @configuration.client, @options.reporting).send_report
+    end
+  end
+end
+
+module GraphQLHive
+  class Tracing
+    include Singleton
+
+    attr_accessor :configuration
+
+    Operation = Data.define(:timestamp, :queries, :results, :elapsed_ns)
+
+    def initialize
+      @usage_reporter = nil
     end
 
-    def measure_execution
-      starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      results = yield
-      ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      duration = ((ending - starting) * (10**9)).to_i
+    def trace(resource:, queries:)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      all_results = yield
+      elapsed_ns = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1e9).to_i
 
-      [results, duration]
-    end
+      usage_reporter.add_operation(
+        Operation.new(
+          Time.now.to_i * 1000,
+          queries,
+          all_results.map(&:to_h),
+          elapsed_ns
+        )
+      )
 
-    # compat
-    def platform_authorized_key(type)
-      "#{type.graphql_name}.authorized.graphql"
-    end
-
-    # compat
-    def platform_resolve_type_key(type)
-      "#{type.graphql_name}.resolve_type.graphql"
-    end
-
-    # compat
-    def platform_field_key(type, field)
-      "graphql.#{type.name}.#{field.name}"
+      all_results
     end
 
     def stop
+      return if @usage_reporter.nil?
       usage_reporter.stop
     end
     alias_method :on_exit, :stop
@@ -113,27 +91,21 @@ module GraphQL
     private
 
     def usage_reporter
-      @usage_reporter ||= GraphQL::Hive::UsageReporter.new(
-        buffer_size: @configuration.buffer_size,
-        client_info: @configuration.client_info,
-        client: @client,
-        sampler: GraphQL::Hive::Sampler.new(
-          sampling_options: @configuration.collect_usage_sampling,
-          logger: @configuration.logger
+      @usage_reporter ||= GraphQLHive::UsageReporter.new(
+        buffer_size: configuration.buffer_size,
+        client_info: configuration.client_info,
+        client: configuration.client,
+        sampler: GraphQLHive::Sampler.new(
+          sampling_options: configuration.collect_usage_sampling,
+          logger: configuration.logger
         ),
-        queue: Thread::SizedQueue.new(@configuration.queue_size),
-        logger: @configuration.logger
+        queue: Thread::SizedQueue.new(configuration.queue_size),
+        logger: configuration.logger
       )
-    end
-
-    def report_schema_to_hive
-      sdl = GraphQL::Schema::Printer.new(@sschema).print_schema
-      reporter = SchemaReporter.new(sdl, @client, @options.reporting)
-      reporter.send_report
     end
   end
 end
 
 at_exit do
-  GraphQL::Hive.instance&.on_exit
+  GraphQLHive::Tracing.instance&.stop
 end

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -30,9 +30,7 @@ module GraphQLHive
     def execute_multiplex(multiplex:)
       return super unless should_collect_usage?
 
-      @tracer.trace(resource: multiplex.queries.first.to_s, queries: multiplex.queries) do
-        super
-      end
+      @tracer.trace(queries: multiplex.queries) { super }
     end
 
     def should_collect_usage?
@@ -60,7 +58,7 @@ module GraphQLHive
       @usage_reporter = nil
     end
 
-    def trace(resource:, queries:)
+    def trace(queries:)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       all_results = yield
       elapsed_ns = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1e9).to_i

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -1,83 +1,81 @@
 # frozen_string_literal: true
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    # Fetch all users fields, input objects and enums
-    class Analyzer < GraphQL::Analysis::AST::Analyzer
-      def initialize(query_or_multiplex)
-        super
-        @used_fields = Set.new
+module GraphQLHive
+  # Fetch all users fields, input objects and enums
+  class Analyzer < GraphQL::Analysis::AST::Analyzer
+    def initialize(query_or_multiplex)
+      super
+      @used_fields = Set.new
+    end
+
+    def on_enter_field(node, _parent, visitor)
+      parent_type = visitor.parent_type_definition
+      if parent_type&.respond_to?(:graphql_name) && node&.respond_to?(:name)
+        @used_fields.add(parent_type.graphql_name)
+        @used_fields.add(make_id(parent_type.graphql_name, node.name))
+      end
+    end
+
+    # Visitor also calls 'on_enter_argument' when visiting input object fields in arguments
+    def on_enter_argument(node, parent, visitor)
+      arg_type = visitor.argument_definition.type.unwrap
+      @used_fields.add(arg_type.graphql_name)
+
+      # collect field argument path
+      # input object fields won't have a "parent.name" method available
+      if parent.respond_to?(:name)
+        @used_fields.add(make_id(visitor.parent_type_definition.graphql_name, parent.name, node.name))
       end
 
-      def on_enter_field(node, _parent, visitor)
-        parent_type = visitor.parent_type_definition
-        if parent_type&.respond_to?(:graphql_name) && node&.respond_to?(:name)
-          @used_fields.add(parent_type.graphql_name)
-          @used_fields.add(make_id(parent_type.graphql_name, node.name))
+      if arg_type.kind.input_object?
+        collect_input_object_fields(node, arg_type)
+      elsif arg_type.kind.enum?
+        collect_enum_values(node, arg_type)
+      end
+    end
+
+    attr_reader :used_fields
+
+    def result
+      @used_fields
+    end
+
+    private
+
+    def collect_input_object_fields(node, input_type)
+      case node.value
+      when GraphQL::Language::Nodes::VariableIdentifier
+        input_type.all_argument_definitions.map(&:graphql_name).each do |n|
+          @used_fields.add(make_id(input_type.graphql_name, n))
+        end
+      when Array
+        node.value.flat_map(&:arguments).map(&:name).each do |n|
+          @used_fields.add(make_id(input_type.graphql_name, n))
+        end
+      else
+        node.value.arguments.map(&:name).each do |n|
+          @used_fields.add(make_id(input_type.graphql_name, n))
         end
       end
+    end
 
-      # Visitor also calls 'on_enter_argument' when visiting input object fields in arguments
-      def on_enter_argument(node, parent, visitor)
-        arg_type = visitor.argument_definition.type.unwrap
-        @used_fields.add(arg_type.graphql_name)
-
-        # collect field argument path
-        # input object fields won't have a "parent.name" method available
-        if parent.respond_to?(:name)
-          @used_fields.add(make_id(visitor.parent_type_definition.graphql_name, parent.name, node.name))
+    def collect_enum_values(node, enum_type)
+      case node.value
+      when GraphQL::Language::Nodes::VariableIdentifier
+        enum_type.values.values.map(&:graphql_name).each do |n|
+          @used_fields.add(make_id(enum_type.graphql_name, n))
         end
-
-        if arg_type.kind.input_object?
-          collect_input_object_fields(node, arg_type)
-        elsif arg_type.kind.enum?
-          collect_enum_values(node, arg_type)
+      when Array
+        node.value.map(&:name).each do |n|
+          @used_fields.add(make_id(enum_type.graphql_name, n))
         end
+      else
+        @used_fields.add(make_id(enum_type.graphql_name, node.value.name))
       end
+    end
 
-      attr_reader :used_fields
-
-      def result
-        @used_fields
-      end
-
-      private
-
-      def collect_input_object_fields(node, input_type)
-        case node.value
-        when GraphQL::Language::Nodes::VariableIdentifier
-          input_type.all_argument_definitions.map(&:graphql_name).each do |n|
-            @used_fields.add(make_id(input_type.graphql_name, n))
-          end
-        when Array
-          node.value.flat_map(&:arguments).map(&:name).each do |n|
-            @used_fields.add(make_id(input_type.graphql_name, n))
-          end
-        else
-          node.value.arguments.map(&:name).each do |n|
-            @used_fields.add(make_id(input_type.graphql_name, n))
-          end
-        end
-      end
-
-      def collect_enum_values(node, enum_type)
-        case node.value
-        when GraphQL::Language::Nodes::VariableIdentifier
-          enum_type.values.values.map(&:graphql_name).each do |n|
-            @used_fields.add(make_id(enum_type.graphql_name, n))
-          end
-        when Array
-          node.value.map(&:name).each do |n|
-            @used_fields.add(make_id(enum_type.graphql_name, n))
-          end
-        else
-          @used_fields.add(make_id(enum_type.graphql_name, node.value.name))
-        end
-      end
-
-      def make_id(*tokens)
-        tokens.join(".")
-      end
+    def make_id(*tokens)
+      tokens.join(".")
     end
   end
 end

--- a/lib/graphql-hive/client.rb
+++ b/lib/graphql-hive/client.rb
@@ -3,70 +3,68 @@
 require "net/http"
 require "uri"
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    # API client
-    class Client
-      def initialize(options)
-        @port = options.port.to_s
-        @scheme = (@port == "443") ? "https" : "http"
-        @host = options.endpoint
-        @token = options.token
-        @use_ssl = @port == "443"
-        @logger = options.logger
+module GraphQLHive
+  # API client
+  class Client
+    def initialize(port:, endpoint:, token:, logger:)
+      @port = port.to_s
+      @scheme = (@port == "443") ? "https" : "http"
+      @host = endpoint
+      @token = token
+      @use_ssl = @port == "443"
+      @logger = logger
+    end
+
+    def send(path, body, _log_type)
+      uri =
+        URI::HTTP.build(
+          scheme: @scheme,
+          host: @host,
+          port: @port,
+          path: path
+        )
+
+      http = setup_http(uri)
+      request = build_request(uri, body)
+      response = http.request(request)
+
+      code = response.code.to_i
+      if code >= 400 && code < 500
+        error_message = "Unsuccessful response: #{response.code} - #{response.message}"
+        @logger.warn("#{error_message} #{extract_error_details(response)}")
       end
 
-      def send(path, body, _log_type)
-        uri =
-          URI::HTTP.build(
-            scheme: @scheme,
-            host: @host,
-            port: @port,
-            path: path
-          )
+      @logger.debug(response.inspect)
+      @logger.debug(response.body.inspect)
+    rescue => e
+      @logger.fatal("Failed to send data: #{e}")
+    end
 
-        http = setup_http(uri)
-        request = build_request(uri, body)
-        response = http.request(request)
+    def setup_http(uri)
+      http = ::Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = @use_ssl
+      http.read_timeout = 2
+      http
+    end
 
-        code = response.code.to_i
-        if code >= 400 && code < 500
-          error_message = "Unsuccessful response: #{response.code} - #{response.message}"
-          @logger.warn("#{error_message} #{extract_error_details(response)}")
-        end
+    def build_request(uri, body)
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request["Authorization"] = @token
+      request["X-Usage-API-Version"] = "2"
+      request["content-type"] = "application/json"
+      request["User-Agent"] = "Hive@#{GraphQLHive::VERSION}"
+      request["graphql-client-name"] = "Hive Ruby Client"
+      request["graphql-client-version"] = GraphQLHive::VERSION
+      request.body = JSON.generate(body)
+      request
+    end
 
-        @logger.debug(response.inspect)
-        @logger.debug(response.body.inspect)
-      rescue => e
-        @logger.fatal("Failed to send data: #{e}")
-      end
-
-      def setup_http(uri)
-        http = ::Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = @use_ssl
-        http.read_timeout = 2
-        http
-      end
-
-      def build_request(uri, body)
-        request = Net::HTTP::Post.new(uri.request_uri)
-        request["Authorization"] = @token
-        request["X-Usage-API-Version"] = "2"
-        request["content-type"] = "application/json"
-        request["User-Agent"] = "Hive@#{Graphql::Hive::VERSION}"
-        request["graphql-client-name"] = "Hive Ruby Client"
-        request["graphql-client-version"] = Graphql::Hive::VERSION
-        request.body = JSON.generate(body)
-        request
-      end
-
-      def extract_error_details(response)
-        parsed_body = JSON.parse(response.body)
-        return unless parsed_body.is_a?(Hash) && parsed_body["errors"].is_a?(Array)
-        parsed_body["errors"].map { |error| "{ path: #{error["path"]}, message: #{error["message"]} }" }.join(", ")
-      rescue JSON::ParserError
-        "Could not parse response from Hive"
-      end
+    def extract_error_details(response)
+      parsed_body = JSON.parse(response.body)
+      return unless parsed_body.is_a?(Hash) && parsed_body["errors"].is_a?(Array)
+      parsed_body["errors"].map { |error| "{ path: #{error["path"]}, message: #{error["message"]} }" }.join(", ")
+    rescue JSON::ParserError
+      "Could not parse response from Hive"
     end
   end
 end

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -1,59 +1,77 @@
-module GraphQL
-  # GraphQL Hive usage collector and schema reporter
-  class Hive < GraphQL::Tracing::PlatformTracing
-    class Configuration
-      attr_accessor :buffer_size, :client_info, :collect_usage, :collect_usage_sampling, :debug, :enabled, :endpoint, :logger, :port, :queue_size, :read_operations, :report_schema, :reporting, :token
+module GraphQLHive
+  class Configuration
+    attr_accessor :buffer_size,
+      :client_info,
+      :collect_usage,
+      :collect_usage_sampling,
+      :debug,
+      :enabled,
+      :logger,
+      :queue_size,
+      :read_operations,
+      :report_schema,
+      :reporting,
+      :client
 
-      DEFAULT_OPTIONS = {
-        buffer_size: 50,
-        client_info: nil,
-        collect_usage: true,
-        collect_usage_sampling: 1.0,
-        debug: false,
-        enabled: true,
-        endpoint: "app.graphql-hive.com",
-        logger: nil,
-        port: "443",
-        queue_size: 1000,
-        read_operations: true,
-        report_schema: true,
-        reporting: {author: nil, commit: nil, service_name: nil, service_url: nil},
-        token: nil
-      }.freeze
+    DEFAULT_OPTIONS = {
+      buffer_size: 50,
+      client_info: nil,
+      collect_usage: true,
+      collect_usage_sampling: 1.0,
+      debug: false,
+      enabled: true,
+      endpoint: "app.graphql-hive.com",
+      logger: nil,
+      port: "443",
+      queue_size: 1000,
+      read_operations: true,
+      report_schema: true,
+      reporting: {author: nil, commit: nil, service_name: nil, service_url: nil},
+      token: nil
+    }.freeze
 
-      def initialize(opts = {})
-        DEFAULT_OPTIONS.merge(opts).each do |key, value|
-          instance_variable_set(:"@#{key}", value)
-        end
-        setup_logger if @logger.nil?
-        validate!
+    def initialize(opts = {})
+      DEFAULT_OPTIONS.merge(opts).each do |key, value|
+        instance_variable_set(:"@#{key}", value)
       end
+      setup_logger if @logger.nil?
+      # TODO Allow for custom client
+      @client = GraphQLHive::Client.new(
+        port: @port,
+        endpoint: @endpoint,
+        token: @token,
+        logger: @logger
+      )
+      validate!
+    end
 
-      def validate!
-        if !@token && @enabled
-          @logger.warn("GraphQL Hive `token` is missing. Disabling Reporting.")
-          @enabled = false
-          @report_schema = false
-        end
-        if @report_schema && !(@reporting.dig(:author) && @reporting.dig(:commit))
-          @logger.warn("GraphQL Hive `author` and `commit` options are required. Disabling Schema Reporting.")
-          @report_schema = false
-        end
+    alias_method :collect_usage?, :collect_usage
+    alias_method :enabled?, :enabled
+
+    def validate!
+      if !@token && @enabled
+        @logger.warn("GraphQL Hive `token` is missing. Disabling Reporting.")
+        @enabled = false
+        @report_schema = false
       end
-
-      private
-
-      def setup_logger
-        @logger = Logger.new($stderr)
-        original_formatter = Logger::Formatter.new
-
-        @logger.formatter = proc { |severity, datetime, progname, msg|
-          msg = msg.respond_to?(:dump) ? msg.dump : msg
-          original_formatter.call(severity, datetime, progname, "[hive] #{msg}")
-        }
-
-        @logger.level = @debug ? Logger::DEBUG : Logger::INFO
+      if @report_schema && !(@reporting.dig(:author) && @reporting.dig(:commit))
+        @logger.warn("GraphQL Hive `author` and `commit` options are required. Disabling Schema Reporting.")
+        @report_schema = false
       end
+    end
+
+    private
+
+    def setup_logger
+      @logger = Logger.new($stderr)
+      original_formatter = Logger::Formatter.new
+
+      @logger.formatter = proc { |severity, datetime, progname, msg|
+        msg = msg.respond_to?(:dump) ? msg.dump : msg
+        original_formatter.call(severity, datetime, progname, "[hive] #{msg}")
+      }
+
+      @logger.level = @debug ? Logger::DEBUG : Logger::INFO
     end
   end
 end

--- a/lib/graphql-hive/printer.rb
+++ b/lib/graphql-hive/printer.rb
@@ -1,94 +1,92 @@
 # frozen_string_literal: true
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    # - removes literals
-    # - removes aliases
-    # - sort nodes and directives (files, arguments, variables)
-    class Printer < GraphQL::Language::Printer
-      def print_string(str)
-        @out.append(str)
+module GraphQLHive
+  # - removes literals
+  # - removes aliases
+  # - sort nodes and directives (files, arguments, variables)
+  class Printer < GraphQL::Language::Printer
+    def print_string(str)
+      @out.append(str)
+    end
+
+    def print_node(node, indent: "")
+      case node
+      when Float, Integer
+        print_string "0"
+      when String
+        print_string ""
+      else
+        super
       end
+    end
 
-      def print_node(node, indent: "")
-        case node
-        when Float, Integer
-          print_string "0"
-        when String
-          print_string ""
-        else
-          super
-        end
-      end
-
-      # from GraphQL::Language::Printer with sort_by name
-      # ignores aliases
-      def print_field(field, indent: "")
-        print_string(indent)
-        print_string(field.name)
-        if field.arguments.any?
-          print_string("(")
-          field.arguments.sort_by(&:name).each_with_index do |a, i|
-            print_argument(a)
-            print_string(", ") if i < field.arguments.size - 1
-          end
-          print_string(")")
-        end
-        print_directives(field.directives)
-        print_selections(field.selections, indent: indent)
-      end
-
-      def print_directives(directives)
-        super(directives.sort_by(&:name))
-      end
-
-      # from GraphQL::Language::Printer with sort_by name
-      def print_selections(selections, indent: "")
-        sorted_nodes = selections.sort_by do |s|
-          next s.name if s.respond_to?(:name)
-          next s.type.name if s.respond_to?(:type)
-
-          raise "don't know how to sort selection node: #{s.inspect}"
-        end
-        super(sorted_nodes, indent: indent)
-      end
-
-      # from GraphQL::Language::Printer with sort_by name
-      def print_directive(directive)
-        print_string("@")
-        print_string(directive.name)
-
-        return if directive.arguments.blank?
-
+    # from GraphQL::Language::Printer with sort_by name
+    # ignores aliases
+    def print_field(field, indent: "")
+      print_string(indent)
+      print_string(field.name)
+      if field.arguments.any?
         print_string("(")
-        directive.arguments.sort_by(&:name).each_with_index do |a, i|
+        field.arguments.sort_by(&:name).each_with_index do |a, i|
           print_argument(a)
-          print_string(", ") if i < directive.arguments.size - 1
+          print_string(", ") if i < field.arguments.size - 1
+        end
+        print_string(")")
+      end
+      print_directives(field.directives)
+      print_selections(field.selections, indent: indent)
+    end
+
+    def print_directives(directives)
+      super(directives.sort_by(&:name))
+    end
+
+    # from GraphQL::Language::Printer with sort_by name
+    def print_selections(selections, indent: "")
+      sorted_nodes = selections.sort_by do |s|
+        next s.name if s.respond_to?(:name)
+        next s.type.name if s.respond_to?(:type)
+
+        raise "don't know how to sort selection node: #{s.inspect}"
+      end
+      super(sorted_nodes, indent: indent)
+    end
+
+    # from GraphQL::Language::Printer with sort_by name
+    def print_directive(directive)
+      print_string("@")
+      print_string(directive.name)
+
+      return if directive.arguments.blank?
+
+      print_string("(")
+      directive.arguments.sort_by(&:name).each_with_index do |a, i|
+        print_argument(a)
+        print_string(", ") if i < directive.arguments.size - 1
+      end
+      print_string(")")
+    end
+
+    # from GraphQL::Language::Printer with sort_by name
+    def print_operation_definition(operation_definition, indent: "")
+      print_string(indent)
+      print_string(operation_definition.operation_type)
+      if operation_definition.name
+        print_string(" ")
+        print_string(operation_definition.name)
+      end
+
+      if operation_definition.variables.any?
+        print_string("(")
+        operation_definition.variables.sort_by(&:name).each_with_index do |v, i|
+          print_variable_definition(v)
+          print_string(", ") if i < operation_definition.variables.size - 1
         end
         print_string(")")
       end
 
-      # from GraphQL::Language::Printer with sort_by name
-      def print_operation_definition(operation_definition, indent: "")
-        print_string(indent)
-        print_string(operation_definition.operation_type)
-        if operation_definition.name
-          print_string(" ")
-          print_string(operation_definition.name)
-        end
-
-        if operation_definition.variables.any?
-          print_string("(")
-          operation_definition.variables.sort_by(&:name).each_with_index do |v, i|
-            print_variable_definition(v)
-            print_string(", ") if i < operation_definition.variables.size - 1
-          end
-          print_string(")")
-        end
-
-        print_directives(operation_definition.directives)
-        print_selections(operation_definition.selections, indent: indent)
-      end
+      print_directives(operation_definition.directives)
+      print_selections(operation_definition.selections, indent: indent)
     end
   end
 end

--- a/lib/graphql-hive/processor.rb
+++ b/lib/graphql-hive/processor.rb
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    class Processor
-      def initialize(buffer_size:, client:, sampler:, queue:, logger:, client_info: nil)
-        @buffer_size = buffer_size
-        @client = client
-        @sampler = sampler
-        @queue = queue
-        @logger = logger
-        @buffer = []
-      end
+module GraphQLHive
+  class Processor
+    def initialize(buffer_size:, client:, sampler:, queue:, logger:, client_info: nil)
+      @buffer_size = buffer_size
+      @client = client
+      @sampler = sampler
+      @queue = queue
+      @logger = logger
+      @buffer = []
+    end
 
-      def process_queue
-        while (operation = @queue.pop(false))
-          begin
-            @logger.debug("Processing operation from queue: #{operation}")
-            @buffer << operation if @sampler.sample?(operation)
+    def process_queue
+      while (op = @queue.pop(false))
+        # TODO use data class for operation
+        operation = op.deconstruct
+        begin
+          @logger.debug("Processing operation from queue: #{operation}")
+          @buffer << operation if @sampler.sample?(operation)
 
-            if @buffer.size >= @buffer_size
-              @logger.debug("Buffer is full, sending report")
-              flush_buffer
-            end
-          rescue => e
-            @buffer.clear
-            @logger.error(e)
+          if @buffer.size >= @buffer_size
+            @logger.debug("Buffer is full, sending report")
+            flush_buffer
           end
+        rescue => e
+          @buffer.clear
+          @logger.error(e)
         end
-
-        flush_buffer unless @buffer.empty?
       end
 
-      def flush_buffer
-        report = Report.new(operations: @buffer).build
-        @client.send(:"/usage", report, :usage)
-        @buffer.clear
-      end
+      flush_buffer unless @buffer.empty?
+    end
+
+    def flush_buffer
+      report = Report.new(operations: @buffer).build
+      @client.send(:"/usage", report, :usage)
+      @buffer.clear
     end
   end
 end

--- a/lib/graphql-hive/report.rb
+++ b/lib/graphql-hive/report.rb
@@ -1,96 +1,23 @@
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    class Report
-      attr_reader :body
-      def initialize(operations:, client_info: nil)
-        @client_info = client_info
-        @operations = operations
-      end
+module GraphQLHive
+  class Report
+    attr_reader :body
+    def initialize(operations:, client_info: nil)
+      @client_info = client_info
+      @operations = operations
+    end
 
-      def build
-        @body ||= @operations.each_with_object(initialize_report) do |operation, report|
-          timestamp, queries, results, duration = operation
-          errors = errors_from_results(results)
-          operation_name = extract_operation_name(queries)
-          operation_details = build_operation_details(queries)
-          operation_map_key = generate_operation_key(operation_details)
+    def build
+      @body ||= @operations.each_with_object(initialize_report) do |operation, report|
+        timestamp, queries, results, duration = operation
+        errors = errors_from_results(results)
+        operation_name = extract_operation_name(queries)
+        operation_details = build_operation_details(queries)
+        operation_map_key = generate_operation_key(operation_details)
 
-          operation_record = build_operation_record(
-            operation_map_key, timestamp, duration, errors, results
-          )
+        operation_record = build_operation_record(
+          operation_map_key, timestamp, duration, errors, results
+        )
 
-          operation, fields = operation_details
-
-          report[:map][operation_map_key] = {
-            fields: fields.to_a,
-            operationName: operation_name,
-            operation: operation
-          }
-          report[:operations] << operation_record
-          report[:size] += 1
-        end
-      end
-
-      private
-
-      def initialize_report
-        {
-          size: 0,
-          map: {},
-          operations: []
-        }
-      end
-
-      def extract_operation_name(queries)
-        queries.map(&:operations).map(&:keys).flatten.compact.join(", ")
-      end
-
-      def build_operation_details(queries)
-        operation = ""
-        fields = Set.new
-
-        queries.each do |query|
-          analyzer = GraphQL::Hive::Analyzer.new(query)
-          visitor = GraphQL::Analysis::AST::Visitor.new(
-            query: query,
-            analyzers: [analyzer]
-          )
-
-          result = visitor.visit
-          fields.merge(analyzer.result)
-
-          operation += "\n" unless operation.empty?
-          operation += GraphQL::Hive::Printer.new.print(result)
-        end
-
-        [operation, fields]
-      end
-
-      def generate_operation_key(operation_details)
-        operation, = operation_details
-        Digest::MD5.hexdigest(operation)
-      end
-
-      def build_operation_record(operation_map_key, timestamp, duration, errors, results)
-        record = {
-          operationMapKey: operation_map_key,
-          timestamp: timestamp.to_i,
-          execution: {
-            ok: errors[:errorsTotal].zero?,
-            duration: duration,
-            errorsTotal: errors[:errorsTotal]
-          }
-        }
-
-        if results[0] && @client_info
-          context = results[0].query.context
-          record[:metadata] = {client: @client_info.call(context)}
-        end
-
-        record
-      end
-
-      def update_report(report, operation_map_key, operation_name, operation_details, operation_record)
         operation, fields = operation_details
 
         report[:map][operation_map_key] = {
@@ -101,17 +28,88 @@ module GraphQL
         report[:operations] << operation_record
         report[:size] += 1
       end
+    end
 
-      def errors_from_results(results)
-        acc = {errorsTotal: 0}
-        results.each do |result|
-          errors = result.to_h.fetch("errors", [])
-          errors.each do
-            acc[:errorsTotal] += 1
-          end
-        end
-        acc
+    private
+
+    def initialize_report
+      {
+        size: 0,
+        map: {},
+        operations: []
+      }
+    end
+
+    def extract_operation_name(queries)
+      queries.map(&:operations).map(&:keys).flatten.compact.join(", ")
+    end
+
+    def build_operation_details(queries)
+      operation = ""
+      fields = Set.new
+
+      queries.each do |query|
+        analyzer = GraphQLHive::Analyzer.new(query)
+        visitor = GraphQL::Analysis::AST::Visitor.new(
+          query: query,
+          analyzers: [analyzer]
+        )
+
+        result = visitor.visit
+        fields.merge(analyzer.result)
+
+        operation += "\n" unless operation.empty?
+        operation += GraphQLHive::Printer.new.print(result)
       end
+
+      [operation, fields]
+    end
+
+    def generate_operation_key(operation_details)
+      operation, = operation_details
+      Digest::MD5.hexdigest(operation)
+    end
+
+    def build_operation_record(operation_map_key, timestamp, duration, errors, results)
+      record = {
+        operationMapKey: operation_map_key,
+        timestamp: timestamp.to_i,
+        execution: {
+          ok: errors[:errorsTotal].zero?,
+          duration: duration,
+          errorsTotal: errors[:errorsTotal]
+        }
+      }
+
+      if results[0] && @client_info
+        context = results[0].query.context
+        record[:metadata] = {client: @client_info.call(context)}
+      end
+
+      record
+    end
+
+    def update_report(report, operation_map_key, operation_name, operation_details, operation_record)
+      operation, fields = operation_details
+
+      report[:map][operation_map_key] = {
+        fields: fields.to_a,
+        operationName: operation_name,
+        operation: operation
+      }
+      report[:operations] << operation_record
+      report[:size] += 1
+    end
+
+    def errors_from_results(results)
+      acc = {errorsTotal: 0}
+      results.each do |result|
+        errors = result.to_h.fetch("errors", [])
+        errors.each do
+          acc[:errorsTotal] += 1
+        end
+      end
+      acc
     end
   end
 end

--- a/lib/graphql-hive/sampler.rb
+++ b/lib/graphql-hive/sampler.rb
@@ -1,41 +1,39 @@
 # frozen_string_literal: true
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    # Sampler instance for usage reporter
-    class Sampler
-      def initialize(sampling_options:, logger:)
-        @logger = logger
-        # backwards compatibility with old `collect_usage_sampling` field
-        if sampling_options.is_a?(Numeric)
-          @logger.warn(
-            "`collect_usage_sampling` is deprecated for fixed sampling rates, " \
-            "use `collect_usage_sampling: { sample_rate: XX }` instead"
-          )
-          passed_sampling_rate = sampling_options
-          sampling_options = {sample_rate: passed_sampling_rate}
-        end
-
-        sampling_options ||= {}
-
-        @sampler = if sampling_options[:sampler]
-          Sampling::DynamicSampler.new(
-            sampling_options[:sampler],
-            sampling_options[:at_least_once],
-            sampling_options[:key_generator]
-          )
-        else
-          Sampling::BasicSampler.new(
-            sampling_options[:sample_rate],
-            sampling_options[:at_least_once],
-            sampling_options[:key_generator]
-          )
-        end
+module GraphQLHive
+  # Sampler instance for usage reporter
+  class Sampler
+    def initialize(sampling_options:, logger:)
+      @logger = logger
+      # backwards compatibility with old `collect_usage_sampling` field
+      if sampling_options.is_a?(Numeric)
+        @logger.warn(
+          "`collect_usage_sampling` is deprecated for fixed sampling rates, " \
+          "use `collect_usage_sampling: { sample_rate: XX }` instead"
+        )
+        passed_sampling_rate = sampling_options
+        sampling_options = {sample_rate: passed_sampling_rate}
       end
 
-      def sample?(operation)
-        @sampler.sample?(operation)
+      sampling_options ||= {}
+
+      @sampler = if sampling_options[:sampler]
+        Sampling::DynamicSampler.new(
+          sampling_options[:sampler],
+          sampling_options[:at_least_once],
+          sampling_options[:key_generator]
+        )
+      else
+        Sampling::BasicSampler.new(
+          sampling_options[:sample_rate],
+          sampling_options[:at_least_once],
+          sampling_options[:key_generator]
+        )
       end
+    end
+
+    def sample?(operation)
+      @sampler.sample?(operation)
     end
   end
 end

--- a/lib/graphql-hive/sampling/basic_sampler.rb
+++ b/lib/graphql-hive/sampling/basic_sampler.rb
@@ -2,32 +2,30 @@
 
 require "graphql-hive/sampling/sampling_context"
 
-module GraphQL
-  class Hive
-    module Sampling
-      # Basic sampling for operations reporting
-      class BasicSampler
-        include GraphQL::Hive::Sampling::SamplingContext
+module GraphQLHive
+  module Sampling
+    # Basic sampling for operations reporting
+    class BasicSampler
+      include GraphQLHive::Sampling::SamplingContext
 
-        def initialize(client_sample_rate, at_least_once, key_generator)
-          @sample_rate = client_sample_rate || 1
-          @tracked_operations = {}
-          @key_generator = key_generator || DEFAULT_SAMPLE_KEY if at_least_once
-        end
+      def initialize(client_sample_rate, at_least_once, key_generator)
+        @sample_rate = client_sample_rate || 1
+        @tracked_operations = {}
+        @key_generator = key_generator || DEFAULT_SAMPLE_KEY if at_least_once
+      end
 
-        def sample?(operation)
-          if @key_generator
-            sample_context = get_sample_context(operation)
-            operation_key = @key_generator.call(sample_context)
+      def sample?(operation)
+        if @key_generator
+          sample_context = get_sample_context(operation)
+          operation_key = @key_generator.call(sample_context)
 
-            unless @tracked_operations.key?(operation_key)
-              @tracked_operations[operation_key] = true
-              return true
-            end
+          unless @tracked_operations.key?(operation_key)
+            @tracked_operations[operation_key] = true
+            return true
           end
-
-          SecureRandom.random_number <= @sample_rate
         end
+
+        SecureRandom.random_number <= @sample_rate
       end
     end
   end

--- a/lib/graphql-hive/sampling/dynamic_sampler.rb
+++ b/lib/graphql-hive/sampling/dynamic_sampler.rb
@@ -2,32 +2,30 @@
 
 require "graphql-hive/sampling/sampling_context"
 
-module GraphQL
-  class Hive
-    module Sampling
-      # Dynamic sampling for operations reporting
-      class DynamicSampler
-        include GraphQL::Hive::Sampling::SamplingContext
+module GraphQLHive
+  module Sampling
+    # Dynamic sampling for operations reporting
+    class DynamicSampler
+      include GraphQLHive::Sampling::SamplingContext
 
-        def initialize(client_sampler, at_least_once, key_generator)
-          @sampler = client_sampler
-          @tracked_operations = {}
-          @key_generator = key_generator || DEFAULT_SAMPLE_KEY if at_least_once
-        end
+      def initialize(client_sampler, at_least_once, key_generator)
+        @sampler = client_sampler
+        @tracked_operations = {}
+        @key_generator = key_generator || DEFAULT_SAMPLE_KEY if at_least_once
+      end
 
-        def sample?(operation)
-          sample_context = get_sample_context(operation)
+      def sample?(operation)
+        sample_context = get_sample_context(operation)
 
-          if @key_generator
-            operation_key = @key_generator.call(sample_context)
-            unless @tracked_operations.key?(operation_key)
-              @tracked_operations[operation_key] = true
-              return true
-            end
+        if @key_generator
+          operation_key = @key_generator.call(sample_context)
+          unless @tracked_operations.key?(operation_key)
+            @tracked_operations[operation_key] = true
+            return true
           end
-
-          SecureRandom.random_number <= @sampler.call(sample_context)
         end
+
+        SecureRandom.random_number <= @sampler.call(sample_context)
       end
     end
   end

--- a/lib/graphql-hive/sampling/sampling_context.rb
+++ b/lib/graphql-hive/sampling/sampling_context.rb
@@ -1,38 +1,36 @@
 # frozen_string_literal: true
 
-module GraphQL
-  class Hive
-    module Sampling
-      # Helper methods for sampling
-      module SamplingContext
-        private
+module GraphQLHive
+  module Sampling
+    # Helper methods for sampling
+    module SamplingContext
+      private
 
-        DEFAULT_SAMPLE_KEY = proc { |sample_context|
-          md5 = Digest::MD5.new
-          md5.update sample_context[:document].to_query_string
-          md5.hexdigest
-        }
+      DEFAULT_SAMPLE_KEY = proc { |sample_context|
+        md5 = Digest::MD5.new
+        md5.update sample_context[:document].to_query_string
+        md5.hexdigest
+      }
 
-        def get_sample_context(operation)
-          _, queries, results, = operation
+      def get_sample_context(operation)
+        _, queries, results, = operation
 
-          operation_name = queries.map(&:operations).map(&:keys).flatten.compact.join(", ")
+        operation_name = queries.map(&:operations).map(&:keys).flatten.compact.join(", ")
 
-          parsed_definitions = []
-          queries.each do |query|
-            query_document = query.document
-            parsed_definitions.concat(query_document.definitions) if query_document
-          end
-          document = GraphQL::Language::Nodes::Document.new(definitions: parsed_definitions)
-
-          context_value = results[0].query.context
-
-          {
-            operation_name: operation_name,
-            document: document,
-            context_value: context_value
-          }
+        parsed_definitions = []
+        queries.each do |query|
+          query_document = query.document
+          parsed_definitions.concat(query_document.definitions) if query_document
         end
+        document = GraphQL::Language::Nodes::Document.new(definitions: parsed_definitions)
+
+        context_value = results[0].query.context
+
+        {
+          operation_name: operation_name,
+          document: document,
+          context_value: context_value
+        }
       end
     end
   end

--- a/lib/graphql-hive/schema_reporter.rb
+++ b/lib/graphql-hive/schema_reporter.rb
@@ -1,34 +1,36 @@
-class GraphQL::Hive::SchemaReporter
-  REPORT_SCHEMA_MUTATION = <<~MUTATION
-    mutation schemaPublish($input: SchemaPublishInput!) {
-      schemaPublish(input: $input) {
-        __typename
-      }
-    }
-  MUTATION
-
-  def initialize(sdl, client, reporting_options)
-    @sdl = sdl
-    @client = client
-    @reporting_options = reporting_options
-  end
-
-  def send_report
-    body = {
-      query: REPORT_SCHEMA_MUTATION,
-      operationName: "schemaPublish",
-      variables: {
-        input: {
-          sdl: @sdl,
-          author: @reporting_options[:author],
-          commit: @reporting_options[:commit],
-          service: @reporting_options[:service_name],
-          url: @reporting_options[:service_url],
-          force: true
+module GraphQLHive
+  class SchemaReporter
+    REPORT_SCHEMA_MUTATION = <<~MUTATION
+      mutation schemaPublish($input: SchemaPublishInput!) {
+        schemaPublish(input: $input) {
+          __typename
         }
       }
-    }
+    MUTATION
 
-    @client.send(:"/registry", body, :"report-schema")
+    def initialize(sdl, client, reporting_options)
+      @sdl = sdl
+      @client = client
+      @reporting_options = reporting_options
+    end
+
+    def send_report
+      body = {
+        query: REPORT_SCHEMA_MUTATION,
+        operationName: "schemaPublish",
+        variables: {
+          input: {
+            sdl: @sdl,
+            author: @reporting_options[:author],
+            commit: @reporting_options[:commit],
+            service: @reporting_options[:service_name],
+            url: @reporting_options[:service_url],
+            force: true
+          }
+        }
+      }
+
+      @client.send(:"/registry", body, :"report-schema")
+    end
   end
 end

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -5,48 +5,48 @@ require "graphql-hive/analyzer"
 require "graphql-hive/printer"
 require "graphql-hive/processor"
 
-module GraphQL
-  class Hive < GraphQL::Tracing::PlatformTracing
-    class UsageReporter
-      def initialize(buffer_size:, client:, sampler:, queue:, logger:, client_info: nil)
-        @buffer_size = buffer_size
-        @client = client
-        @sampler = sampler
-        @queue = queue
-        @logger = logger
-        start
-      end
-
-      def add_operation(operation)
-        @queue.push(operation, true)
-      rescue ThreadError
-        @logger.error("SizedQueue is full, discarding operation. Size: #{@queue.size}, Max: #{@queue.max}")
-      end
-
-      def start
-        if @thread&.alive?
-          @logger.warn("Usage reporter is already running")
-        end
-
-        @thread = Thread.new do
-          Processor.new(
-            buffer_size: @buffer_size,
-            client: @client,
-            sampler: @sampler,
-            queue: @queue,
-            logger: @logger
-          ).process_queue
-        rescue => e
-          @logger.error(e)
-        end
-      end
-      alias_method :on_start, :start
-
-      def stop
-        @queue.close
-        @thread&.join
-      end
-      alias_method :on_exit, :stop
+module GraphQLHive
+  class UsageReporter
+    def initialize(buffer_size:, client:, sampler:, queue:, logger:, client_info: nil)
+      @buffer_size = buffer_size
+      @client = client
+      @sampler = sampler
+      @queue = queue
+      @logger = logger
+      start
     end
+
+    def add_operation(operation)
+      @queue.push(operation, true)
+    rescue ThreadError
+      @logger.error("SizedQueue is full, discarding operation. Size: #{@queue.size}, Max: #{@queue.max}")
+    end
+
+    def start
+      if @thread&.alive?
+        @logger.warn("Usage reporter is already running")
+      end
+
+      # TODO consider using Fibers instead of threads because they are lighter weight
+      # and this work is not CPU intensive.
+      @thread = Thread.new do
+        Processor.new(
+          buffer_size: @buffer_size,
+          client: @client,
+          sampler: @sampler,
+          queue: @queue,
+          logger: @logger
+        ).process_queue
+      rescue => e
+        @logger.error(e)
+      end
+    end
+    alias_method :on_start, :start
+
+    def stop
+      @queue.close
+      @thread&.join
+    end
+    alias_method :on_exit, :stop
   end
 end

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-module Graphql
-  module Hive
-    VERSION = "0.5.4"
-  end
+module GraphQLHive
+  VERSION = "0.5.4"
 end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -2,10 +2,10 @@
 
 require "spec_helper"
 
-RSpec.describe "GraphQL::Hive::Analyzer" do
+RSpec.describe "GraphQLHive::Analyzer" do
   subject(:used_fields) do
     query = GraphQL::Query.new(schema, query_string)
-    analyzer = GraphQL::Hive::Analyzer.new(query)
+    analyzer = GraphQLHive::Analyzer.new(query)
     visitor = GraphQL::Analysis::AST::Visitor.new(
       query: query,
       analyzers: [analyzer]

--- a/spec/graphql/graphql-hive/configuration_spec.rb
+++ b/spec/graphql/graphql-hive/configuration_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "logger"
 
-RSpec.describe GraphQL::Hive::Configuration do
+RSpec.describe GraphQLHive::Configuration do
   let(:logger) { instance_double(Logger) }
 
   before do
@@ -34,11 +34,15 @@ RSpec.describe GraphQL::Hive::Configuration do
         expect(config.collect_usage_sampling).to eq(1.0)
         expect(config.debug).to be false
         expect(config.enabled).to be false # disabled due to missing token
-        expect(config.endpoint).to eq("app.graphql-hive.com")
-        expect(config.port).to eq("443")
         expect(config.queue_size).to eq(1000)
         expect(config.read_operations).to be true
         expect(config.report_schema).to be false # disabled due to missing reporting info
+
+        client = config.client
+        expect(client).to be_a(GraphQLHive::Client)
+        expect(client.instance_variable_get(:@token)).to be_nil
+        expect(client.instance_variable_get(:@host)).to eq("app.graphql-hive.com")
+        expect(client.instance_variable_get(:@port)).to eq("443")
       end
 
       it "creates a logger with correct settings" do
@@ -65,7 +69,7 @@ RSpec.describe GraphQL::Hive::Configuration do
       subject(:config) { described_class.new(valid_options) }
 
       it "merges custom options with defaults" do
-        expect(config.token).to eq("test-token")
+        expect(config.client.instance_variable_get(:@token)).to eq("test-token")
         expect(config.reporting).to include(
           author: "test-author",
           commit: "test-commit"

--- a/spec/graphql/graphql-hive/printer_spec.rb
+++ b/spec/graphql/graphql-hive/printer_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "GraphQL::Hive::Printer" do
+RSpec.describe "GraphQLHive::Printer" do
   let(:schema) do
     GraphQL::Schema.from_definition(%|
     """
@@ -70,7 +70,7 @@ RSpec.describe "GraphQL::Hive::Printer" do
       }
     GRAPHQL
 
-    expect(GraphQL::Hive::Printer.new.print(query.document)).to eq(expected_result)
+    expect(GraphQLHive::Printer.new.print(query.document)).to eq(expected_result)
   end
 
   context "with query containing inline and spread fragment selections" do
@@ -123,7 +123,7 @@ RSpec.describe "GraphQL::Hive::Printer" do
         }
       GRAPHQL
 
-      expect(GraphQL::Hive::Printer.new.print(query.document)).to eq(expected_result)
+      expect(GraphQLHive::Printer.new.print(query.document)).to eq(expected_result)
     end
   end
 end

--- a/spec/graphql/graphql-hive/processor_spec.rb
+++ b/spec/graphql/graphql-hive/processor_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
-RSpec.describe GraphQL::Hive::Processor do
+RSpec.describe GraphQLHive::Processor do
   let(:buffer_size) { 2 }
-  let(:client) { instance_double("GraphQL::Hive::Client") }
-  let(:sampler) { instance_double("GraphQL::Hive::Sampler") }
+  let(:client) { instance_double("GraphQLHive::Client") }
+  let(:sampler) { instance_double("GraphQLHive::Sampler") }
   let(:queue) { instance_double("Thread::SizedQueue") }
   let(:logger) { instance_double("Logger") }
   let(:query) do
@@ -12,17 +12,17 @@ RSpec.describe GraphQL::Hive::Processor do
       context: double("Context"))
   end
   let(:operation) do
-    [
+    GraphQLHive::Tracing::Operation.new(
       Time.now,
       [query],
       [double("Result", query: query, to_h: {"data" => {}, "errors" => []})],
       100
-    ]
+    )
   end
   let(:analyzer_result) { double("AnalyzerResult") }
-  let(:analyzer) { instance_double(GraphQL::Hive::Analyzer, result: Set.new(["field1", "field2"])) }
+  let(:analyzer) { instance_double(GraphQLHive::Analyzer, result: Set.new(["field1", "field2"])) }
   let(:visitor) { instance_double(GraphQL::Analysis::AST::Visitor) }
-  let(:printer) { instance_double(GraphQL::Hive::Printer) }
+  let(:printer) { instance_double(GraphQLHive::Printer) }
   let(:processor) do
     described_class.new(
       buffer_size: buffer_size,
@@ -69,10 +69,10 @@ RSpec.describe GraphQL::Hive::Processor do
     allow(logger).to receive(:error)
     allow(client).to receive(:send)
     allow(sampler).to receive(:sample?).and_return(true)
-    allow(GraphQL::Hive::Analyzer).to receive(:new).and_return(analyzer)
+    allow(GraphQLHive::Analyzer).to receive(:new).and_return(analyzer)
     allow(GraphQL::Analysis::AST::Visitor).to receive(:new).and_return(visitor)
     allow(visitor).to receive(:visit).and_return(analyzer_result)
-    allow(GraphQL::Hive::Printer).to receive(:new).and_return(printer)
+    allow(GraphQLHive::Printer).to receive(:new).and_return(printer)
     allow(printer).to receive(:print).and_return("query TestOperation { field1 field2 }")
   end
 
@@ -91,8 +91,6 @@ RSpec.describe GraphQL::Hive::Processor do
     end
 
     context "when an error occurs" do
-      let(:operation) { {query: "query1"} }
-
       before do
         allow(sampler).to receive(:sample?).and_raise(StandardError.new("Test error"))
       end

--- a/spec/graphql/graphql-hive/report_spec.rb
+++ b/spec/graphql/graphql-hive/report_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
-RSpec.describe GraphQL::Hive::Report do
+RSpec.describe GraphQLHive::Report do
   subject(:report) { described_class.new(client_info: client_info, operations: [operation]) }
   let(:client_info) { ->(context) { {name: "test_client"} } }
   let(:analyzer_result) { double("AnalyzerResult") }
-  let(:analyzer) { instance_double(GraphQL::Hive::Analyzer, result: Set.new(["field1", "field2"])) }
+  let(:analyzer) { instance_double(GraphQLHive::Analyzer, result: Set.new(["field1", "field2"])) }
   let(:visitor) { instance_double(GraphQL::Analysis::AST::Visitor) }
-  let(:printer) { instance_double(GraphQL::Hive::Printer) }
+  let(:printer) { instance_double(GraphQLHive::Printer) }
   let(:query) do
     double("Query",
       operations: {"TestOperation" => {}},
@@ -46,10 +46,10 @@ RSpec.describe GraphQL::Hive::Report do
     end
     before do
       Timecop.freeze(now)
-      allow(GraphQL::Hive::Analyzer).to receive(:new).and_return(analyzer)
+      allow(GraphQLHive::Analyzer).to receive(:new).and_return(analyzer)
       allow(GraphQL::Analysis::AST::Visitor).to receive(:new).and_return(visitor)
       allow(visitor).to receive(:visit).and_return(analyzer_result)
-      allow(GraphQL::Hive::Printer).to receive(:new).and_return(printer)
+      allow(GraphQLHive::Printer).to receive(:new).and_return(printer)
       allow(printer).to receive(:print).and_return("query TestOperation { field1 field2 }")
     end
 

--- a/spec/graphql/graphql-hive/sampler/basic_sampler_spec.rb
+++ b/spec/graphql/graphql-hive/sampler/basic_sampler_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe GraphQL::Hive::Sampling::BasicSampler do
+RSpec.describe GraphQLHive::Sampling::BasicSampler do
   let(:sampler_instance) { described_class.new(sample_rate, at_least_once, key_generator) }
   let(:sample_rate) { 0 }
   let(:at_least_once) { false }

--- a/spec/graphql/graphql-hive/sampler/dynamic_sampler_spec.rb
+++ b/spec/graphql/graphql-hive/sampler/dynamic_sampler_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe GraphQL::Hive::Sampling::DynamicSampler do
+RSpec.describe GraphQLHive::Sampling::DynamicSampler do
   let(:sampler_instance) { described_class.new(sampler, at_least_once, key_generator) }
   let(:sampler) { proc { |_sample_context| 0 } }
   let(:at_least_once) { false }

--- a/spec/graphql/graphql-hive/sampler_spec.rb
+++ b/spec/graphql/graphql-hive/sampler_spec.rb
@@ -2,21 +2,21 @@
 
 require "spec_helper"
 
-RSpec.describe GraphQL::Hive::Sampler do
+RSpec.describe GraphQLHive::Sampler do
   let(:sampler_instance) { described_class.new(sampling_options: sampling_options, logger: logger) }
   let(:sampling_options) { nil }
   let(:logger) { instance_double("Logger") }
 
   describe "#initialize" do
     it "creates a basic sampler" do
-      expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQL::Hive::Sampling::BasicSampler)
+      expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
     end
 
     context "when provided a sampling rate" do
       let(:sampling_options) { {sample_rate: 0.5} }
 
       it "creates a basic sampler" do
-        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQL::Hive::Sampling::BasicSampler)
+        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
       end
 
       context "using the deprecated field" do
@@ -27,7 +27,7 @@ RSpec.describe GraphQL::Hive::Sampler do
         end
 
         it "creates a basic sampler" do
-          expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQL::Hive::Sampling::BasicSampler)
+          expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::BasicSampler)
         end
 
         it "logs a warning" do
@@ -41,7 +41,7 @@ RSpec.describe GraphQL::Hive::Sampler do
       let(:sampling_options) { {sampler: proc {}} }
 
       it "creates a dynamic sampler" do
-        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQL::Hive::Sampling::DynamicSampler)
+        expect(sampler_instance.instance_variable_get(:@sampler)).to be_an_instance_of(GraphQLHive::Sampling::DynamicSampler)
       end
     end
   end

--- a/spec/graphql/graphql-hive/schema_reporter_spec.rb
+++ b/spec/graphql/graphql-hive/schema_reporter_spec.rb
@@ -1,6 +1,6 @@
-RSpec.describe GraphQL::Hive::SchemaReporter do
+RSpec.describe GraphQLHive::SchemaReporter do
   let(:sdl) { "type Query { hello: String }" }
-  let(:client) { instance_double("GraphQL::Hive::Client") }
+  let(:client) { instance_double("GraphQLHive::Client") }
   let(:reporting_options) do
     {
       author: "test_author",

--- a/spec/graphql/graphql-hive/usage_reporter_spec.rb
+++ b/spec/graphql/graphql-hive/usage_reporter_spec.rb
@@ -1,7 +1,7 @@
-RSpec.describe GraphQL::Hive::UsageReporter do
+RSpec.describe GraphQLHive::UsageReporter do
   let(:buffer_size) { 10 }
-  let(:client) { instance_double("GraphQL::Hive::Client") }
-  let(:sampler) { instance_double("GraphQL::Hive::Sampler") }
+  let(:client) { instance_double("GraphQLHive::Client") }
+  let(:sampler) { instance_double("GraphQLHive::Sampler") }
   let(:queue) { instance_double("SizedQueue") }
   let(:logger) { instance_double("Logger") }
   let(:client_info) { ->(ctx) { {name: "test-client"} } }

--- a/spec/graphql/hive_spec.rb
+++ b/spec/graphql/hive_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Graphql::Hive do
+RSpec.describe GraphQLHive do
   it "has a version number" do
-    expect(Graphql::Hive::VERSION).not_to be nil
+    expect(GraphQLHive::VERSION).not_to be nil
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe TestApp do
   end
 
   after do
-    GraphQL::Hive.instance.on_exit
+    GraphQLHive::Tracing.instance.stop
   end
 
   it("posts data to hive", :aggregate_failures, :vcr) do

--- a/spec/test_app/app.rb
+++ b/spec/test_app/app.rb
@@ -26,15 +26,16 @@ end
 class Schema < GraphQL::Schema
   query QueryType
 
-  use(
-    GraphQL::Hive,
+  trace_with(
+    GraphQLHive::Trace,
     enabled: true,
     token: "fake-token",
     report_schema: false,
     collect_usage_sampling: {
       sample_rate: 1
     },
-    buffer_size: 5
+    buffer_size: 5,
+    schema: self
   )
 end
 
@@ -43,7 +44,7 @@ class TestApp < Sinatra::Base
     request.body.rewind
     params = JSON.parse(request.body.read)
     result = Schema.execute(
-      params["query"],
+      query: params["query"],
       variables: params["variables"],
       operation_name: params["operationName"],
       context: {
@@ -53,5 +54,8 @@ class TestApp < Sinatra::Base
     )
     content_type :json
     JSON.dump(result)
+  rescue => e
+    status 500
+    JSON.dump("errors" => [e.message])
   end
 end


### PR DESCRIPTION
### Added
- Works with `Schema.trace_with` you will need to update your schema to use this method. There is an example in app.rb

### Removed
- No longer works with `Schema.use` as this is deprecated in graphql-ruby.
- Namespace conflict with `GraphQL`. Everything is now named `GraphQLHive`.

### Changed
- Only start reporter if it is needed
