### PR TITLE
Manually report schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Works with `Schema.trace_with` you will need to update your schema to use this method. There is an example in app.rb
 - BREAKING: You must now configure the gem in an initializer. See README.md for more details.
+- Added `GraphQLHive.report_schema_to_hive` method to report your schema to Hive either on boot or in CI.
 
 ### Removed
 - BREAKING: No longer works with `Schema.use` as this is deprecated in graphql-ruby.
 - BREAKING: Namespace conflict with `GraphQL`. Everything is now named `GraphQLHive`.
 - BREAKING: Support for Ruby 3.1 as it will reach EOL in March 2025.
+- BREAKING: Removed `reporting` and `report_schema` options. You will now have to do this manually.
 
 ### Changed
 - Refactored graphql-hive.rb to us a configuration class

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 
 # Getting started
 
-
 ## 0. Get your Hive token
 
 If you are using Hive as a service, please refer to our documentation: https://docs.graphql-hive.com/features/tokens.
@@ -34,10 +33,6 @@ Add `GraphQLHive` **at the end** of your schema definition:
 # app/initializers/graphql_hive.rb
 GraphQLHive.configure do |config|
   config.token = '<YOUR_TOKEN>'
-  config.reporting = {
-    author: ENV['GITHUB_USER'],
-    commit: ENV['GITHUB_COMMIT']
-  }
 end
 
 # schema.rb
@@ -49,11 +44,27 @@ end
 
 ```
 
-The `reporting` configuration is required to push your GraphQL Schema to the Hive registry.
-Doing so will help better detect breaking changes and more upcoming features.
-If you only want to use the operations monitoring, replace the `reporting` option with the following `report_schema: false`.
+## 3. (Optional) Report your schema to Hive
 
-## 3. (Optional) Configure Lifecycle Hooks
+If you want to report your schema to Hive, you can do so by calling the `report_schema_to_hive` method. You can call this method in the initializer file or in CI.
+
+```ruby
+# app/initializers/graphql_hive.rb
+GraphQLHive.report_schema_to_hive(
+  schema: Schema,
+  options: {
+    # Required
+    author: ENV['GITHUB_USER'],
+    commit: ENV['GITHUB_COMMIT'],
+    # Optional
+    service: ENV['GRAPHQL_HIVE_SERVICE_NAME'],
+    url: ENV['GRAPHQL_HIVE_SERVICE_URL'],
+    force: ENV['GRAPHQL_HIVE_FORCE_REPORT']
+  }
+)
+```
+
+## 4. (Optional) Configure Lifecycle Hooks
 
 Calling these hooks are situational - it's likely that you may not need to call
 them at all!
@@ -96,7 +107,7 @@ When deploying or starting up your GraphQL API, `graphql-hive` will immediately:
 - publish the schema to the Hive registry
 - forward the operations metrics to Hive
 
-## 4. See how your GraphQL API is operating
+## 5. See how your GraphQL API is operating
 
 You should now see operations information (RPM, error rate, queries performed) on your [GraphQL Hive dashboard](https://app.graphql-hive.com/):
 
@@ -104,7 +115,7 @@ You should now see operations information (RPM, error rate, queries performed) o
   <img src="operations-dashboard.png" width="500" alt="GraphQL Hive" />
 </p>
 
-## 5. Going further: use the Hive Github app
+## 6. Going further: use the Hive Github app
 
 Stay on top of your GraphQL Schema changes by installing the Hive Github Application and enabling Slack notifications about breaking changes:
 
@@ -149,17 +160,6 @@ GraphQLHive.configure do |config|
     at_least_once: true,
     # Assign custom keys to distinguish between distinct operations.
     key_generator: proc { |context| context.operation_name }
-  }
-  # Publish schema to Hive.
-  config.report_schema = true
-  # Mandatory if `report_schema: true`.
-  config.reporting = {
-    # Mandatory members of `reporting`.
-    author: 'Author of the latest change',
-    commit: 'git sha or any identifier',
-    # Optional members of `reporting`.
-    service_name: '',
-    service_url: '',
   }
 
   # Pass an optional proc to client_info to help identify the client (ex: Apollo web app) that performed the query.

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -39,5 +39,10 @@ module GraphQLHive
     def stop
       GraphQLHive.configuration.usage_reporter.stop
     end
+
+    def report_schema_to_hive(schema:, options: {})
+      sdl = GraphQL::Schema::Printer.new(schema).print_schema
+      SchemaReporter.new(sdl: sdl, options: options).send_report
+    end
   end
 end

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -43,6 +43,11 @@ module GraphQLHive
     def report_schema_to_hive(schema:, options: {})
       sdl = GraphQL::Schema::Printer.new(schema).print_schema
       SchemaReporter.new(sdl: sdl, options: options).send_report
+    rescue => e
+      configuration.logger.error("Failed to report schema to Hive: #{e.message}")
+      if configuration.debug
+        configuration.logger.debug(e.backtrace.join("\n"))
+      end
     end
   end
 end

--- a/lib/graphql-hive/configuration.rb
+++ b/lib/graphql-hive/configuration.rb
@@ -10,8 +10,6 @@ module GraphQLHive
       :logger,
       :queue_size,
       :read_operations,
-      :report_schema,
-      :reporting,
       :schema,
       :token
 
@@ -27,8 +25,6 @@ module GraphQLHive
       port: "443",
       queue_size: 1000,
       read_operations: true,
-      report_schema: true,
-      reporting: {author: nil, commit: nil, service_name: nil, service_url: nil},
       token: nil
     }.freeze
 
@@ -54,11 +50,6 @@ module GraphQLHive
       if !@token && @enabled
         @logger.warn("GraphQL Hive `token` is missing. Disabling Reporting.")
         @enabled = false
-        @report_schema = false
-      end
-      if @report_schema && !(@reporting.dig(:author) && @reporting.dig(:commit))
-        @logger.warn("GraphQL Hive `author` and `commit` options are required. Disabling Schema Reporting.")
-        @report_schema = false
       end
     end
 

--- a/lib/graphql-hive/schema_reporter.rb
+++ b/lib/graphql-hive/schema_reporter.rb
@@ -8,29 +8,37 @@ module GraphQLHive
       }
     MUTATION
 
-    def initialize(sdl, client, reporting_options)
+    def initialize(sdl:, options:)
       @sdl = sdl
-      @client = client
-      @reporting_options = reporting_options
+      @options = options
+      @client = GraphQLHive.configuration.client
     end
 
     def send_report
+      validate_options!
       body = {
         query: REPORT_SCHEMA_MUTATION,
         operationName: "schemaPublish",
         variables: {
           input: {
             sdl: @sdl,
-            author: @reporting_options[:author],
-            commit: @reporting_options[:commit],
-            service: @reporting_options[:service_name],
-            url: @reporting_options[:service_url],
-            force: true
+            author: @options[:author],
+            commit: @options[:commit],
+            service: @options[:service],
+            url: @options[:url],
+            force: @options[:force]
           }
         }
       }
 
       @client.send(:"/registry", body, :"report-schema")
+    end
+
+    private
+
+    def validate_options!
+      raise ArgumentError, "author is required for schema reporting" if @options[:author].nil?
+      raise ArgumentError, "commit is required for schema reporting" if @options[:commit].nil?
     end
   end
 end

--- a/lib/graphql-hive/trace.rb
+++ b/lib/graphql-hive/trace.rb
@@ -5,8 +5,6 @@ module GraphQLHive
       @hive = GraphQLHive::Tracing.new(
         usage_reporter: @configuration.usage_reporter
       )
-      # TODO put in configuration so we don't call this on every trace
-      report_schema_to_hive(@configuration.schema)
       super
     end
 
@@ -20,13 +18,6 @@ module GraphQLHive
 
     def _should_collect_usage?
       @configuration.enabled? && @configuration.collect_usage?
-    end
-
-    def report_schema_to_hive(schema)
-      return if schema.nil? || !@configuration.report_schema
-
-      sdl = GraphQL::Schema::Printer.new(schema).print_schema
-      SchemaReporter.new(sdl, @configuration.client, @options.reporting).send_report
     end
   end
 end

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -2,4 +2,8 @@
 
 module GraphQLHive
   VERSION = "0.5.4"
+
+  def self.gem_version
+    Gem::Version.new(VERSION)
+  end
 end

--- a/spec/graphql-hive/configuration_spec.rb
+++ b/spec/graphql-hive/configuration_spec.rb
@@ -6,12 +6,7 @@ RSpec.describe GraphQLHive::Configuration do
   let(:logger) { instance_double(Logger) }
   let(:valid_options) do
     {
-      token: "test-token",
-      report_schema: true,
-      reporting: {
-        author: "test-author",
-        commit: "test-commit"
-      }
+      token: "test-token"
     }
   end
 
@@ -34,7 +29,6 @@ RSpec.describe GraphQLHive::Configuration do
         expect(config.enabled).to be true
         expect(config.queue_size).to eq(1000)
         expect(config.read_operations).to be true
-        expect(config.report_schema).to be true
 
         client = config.client
         expect(client).to be_a(GraphQLHive::Client)
@@ -49,10 +43,6 @@ RSpec.describe GraphQLHive::Configuration do
 
       it "merges custom options with defaults" do
         expect(config.client.instance_variable_get(:@token)).to eq("test-token")
-        expect(config.reporting).to include(
-          author: "test-author",
-          commit: "test-commit"
-        )
       end
     end
   end
@@ -85,38 +75,7 @@ RSpec.describe GraphQLHive::Configuration do
 
       it "disables the service and logs a warning" do
         expect(config.enabled).to be false
-        expect(config.report_schema).to be false
         expect(logger).to have_received(:warn).with(/token.*missing/)
-      end
-    end
-
-    context "when author is missing" do
-      subject(:config) do
-        described_class.new(
-          token: "test-token",
-          logger: logger,
-          reporting: {commit: "test-commit"}
-        )
-      end
-
-      it "disables schema reporting and logs a warning" do
-        expect(config.report_schema).to be false
-        expect(logger).to have_received(:warn).with(/author.*commit.*required/)
-      end
-    end
-
-    context "when commit is missing" do
-      subject(:config) do
-        described_class.new(
-          token: "test-token",
-          logger: logger,
-          reporting: {author: "test-author"}
-        )
-      end
-
-      it "disables schema reporting and logs a warning" do
-        expect(config.report_schema).to be false
-        expect(logger).to have_received(:warn).with(/author.*commit.*required/)
       end
     end
 

--- a/spec/graphql-hive/schema_reporter_spec.rb
+++ b/spec/graphql-hive/schema_reporter_spec.rb
@@ -1,49 +1,82 @@
 RSpec.describe GraphQLHive::SchemaReporter do
   let(:sdl) { "type Query { hello: String }" }
-  let(:client) { instance_double("GraphQLHive::Client") }
-  let(:reporting_options) do
+  let(:options) do
     {
       author: "test_author",
       commit: "abc123",
-      service_name: "test_service",
-      service_url: "http://example.com"
+      service: "test-service",
+      url: "http://test.com",
+      force: true
     }
   end
+  let(:config) { instance_double(GraphQLHive::Configuration) }
+  let(:client) { instance_double(GraphQLHive::Client) }
 
-  subject { described_class.new(sdl, client, reporting_options) }
+  before do
+    allow(GraphQLHive).to receive(:configuration).and_return(config)
+    allow(config).to receive(:client).and_return(client)
+  end
+
+  subject { described_class.new(sdl: sdl, options: options) }
 
   describe "#initialize" do
     it "sets the instance variables correctly" do
       expect(subject.instance_variable_get(:@sdl)).to eq(sdl)
+      expect(subject.instance_variable_get(:@options)).to eq(options)
       expect(subject.instance_variable_get(:@client)).to eq(client)
-      expect(subject.instance_variable_get(:@reporting_options)).to eq(reporting_options)
     end
   end
 
   describe "#send_report" do
-    it "sends the correct mutation to the client" do
-      expected_body = {
-        query: described_class::REPORT_SCHEMA_MUTATION,
-        operationName: "schemaPublish",
-        variables: {
-          input: {
-            sdl: sdl,
-            author: reporting_options[:author],
-            commit: reporting_options[:commit],
-            service: reporting_options[:service_name],
-            url: reporting_options[:service_url],
-            force: true
+    context "with valid reporting options" do
+      it "sends the correct mutation to the client" do
+        expected_body = {
+          query: described_class::REPORT_SCHEMA_MUTATION,
+          operationName: "schemaPublish",
+          variables: {
+            input: {
+              sdl: sdl,
+              author: options[:author],
+              commit: options[:commit],
+              service: options[:service],
+              url: options[:url],
+              force: options[:force]
+            }
           }
         }
-      }
 
-      allow(client).to receive(:send)
+        allow(client).to receive(:send)
 
-      subject.send_report
+        subject.send_report
 
-      expect(client).to have_received(:send)
-        .with(:"/registry", expected_body, :"report-schema")
-        .once
+        expect(client).to have_received(:send)
+          .with(:"/registry", expected_body, :"report-schema")
+          .once
+      end
+    end
+
+    context "with invalid reporting options" do
+      context "when author is missing" do
+        let(:options) { {commit: "abc123"} }
+
+        it "raises an ArgumentError" do
+          expect { subject.send_report }.to raise_error(
+            ArgumentError,
+            "author is required for schema reporting"
+          )
+        end
+      end
+
+      context "when commit is missing" do
+        let(:options) { {author: "test_author"} }
+
+        it "raises an ArgumentError" do
+          expect { subject.send_report }.to raise_error(
+            ArgumentError,
+            "commit is required for schema reporting"
+          )
+        end
+      end
     end
   end
 end

--- a/spec/graphql-hive/version_spec.rb
+++ b/spec/graphql-hive/version_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphQLHive do
+  describe "VERSION" do
+    it "is defined" do
+      expect(GraphQLHive::VERSION).not_to be_nil
+    end
+
+    it "follows semantic versioning format" do
+      expect(GraphQLHive::VERSION).to match(/^\d+\.\d+\.\d+$/)
+    end
+  end
+
+  describe ".gem_version" do
+    it "returns a Gem::Version instance" do
+      expect(GraphQLHive.gem_version).to be_a(Gem::Version)
+    end
+
+    it "matches VERSION constant" do
+      expect(GraphQLHive.gem_version.to_s).to eq(GraphQLHive::VERSION)
+    end
+  end
+end

--- a/spec/graphql-hive_spec.rb
+++ b/spec/graphql-hive_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe GraphQLHive do
+  let(:schema) { Class.new(GraphQL::Schema) }
+  let(:author) { "test author" }
+  let(:commit) { "test commit" }
+  let(:config) do
+    GraphQLHive.configure do |c|
+      c.token = "test-token"
+      c.enabled = true
+      c.schema = schema
+    end
+  end
+
+  before do
+    GraphQLHive.configuration = nil
+  end
+
+  describe ".configure" do
+    it "yields configuration object" do
+      expect { |b| GraphQLHive.configure(&b) }.to yield_with_args(GraphQLHive::Configuration)
+    end
+
+    it "returns configuration object" do
+      expect(GraphQLHive.configure).to be_a(GraphQLHive::Configuration)
+    end
+
+    it "validates configuration" do
+      config = GraphQLHive.configure
+      expect(config.logger).not_to be_nil
+    end
+
+    it "stores configuration" do
+      config = GraphQLHive.configure
+      expect(GraphQLHive.configuration).to eq(config)
+    end
+  end
+
+  describe ".start" do
+    it "starts the usage reporter" do
+      config
+      expect(GraphQLHive.configuration.usage_reporter).to receive(:start)
+      GraphQLHive.start
+    end
+  end
+
+  describe ".stop" do
+    it "stops the usage reporter" do
+      config
+      expect(GraphQLHive.configuration.usage_reporter).to receive(:stop)
+      GraphQLHive.stop
+    end
+  end
+
+  describe ".report_schema_to_hive" do
+    let(:reporter) { instance_double(GraphQLHive::SchemaReporter) }
+    let(:sdl) { "type Query { test: String }" }
+
+    before do
+      config
+      allow(GraphQL::Schema::Printer).to receive(:new).with(schema).and_return(double(print_schema: sdl))
+      allow(GraphQLHive::SchemaReporter).to receive(:new).and_return(reporter)
+      allow(reporter).to receive(:send_report)
+    end
+
+    it "sends schema report" do
+      GraphQLHive.report_schema_to_hive(schema: schema, options: {author: author, commit: commit})
+      expect(reporter).to have_received(:send_report)
+    end
+
+    it "creates reporter with correct params" do
+      options = {
+        author: author,
+        commit: commit
+      }
+      GraphQLHive.report_schema_to_hive(schema: schema, options: options)
+      expect(GraphQLHive::SchemaReporter).to have_received(:new).with(
+        sdl: sdl,
+        options: options
+      )
+    end
+  end
+end

--- a/spec/hive_spec.rb
+++ b/spec/hive_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe GraphQLHive do
-  it "has a version number" do
-    expect(GraphQLHive::VERSION).not_to be nil
-  end
-end

--- a/spec/test_app/app.rb
+++ b/spec/test_app/app.rb
@@ -32,12 +32,10 @@ end
 GraphQLHive.configure do |config|
   config.enabled = true
   config.token = "fake-token"
-  config.report_schema = false
   config.collect_usage_sampling = {
     sample_rate: 1
   }
   config.buffer_size = 5
-  config.schema = self
 end
 
 class TestApp < Sinatra::Base


### PR DESCRIPTION
Manually report schema to Hive to give users better control over when this happens

I did this for a couple reason:

- Because trace_with now initializes an instance on each request, automatic reporting was moved to configuration in my previous commit.
- I did not like that configuration would automatically issue an HTTP call as this is not the expected behaviour of what is essentially a data class.
- Manually calling reporting methods gives users more control over when the schema is reported. They can choose to do this in CI or on app boot.