### PR TITLE
fix graphql compat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    graphql-hive (0.5.4)
-      graphql (>= 2.3, < 3)
+    graphql-hive (0.5.5)
+      graphql (>= 2.4.12, < 3)
       logger
 
 GEM
@@ -23,9 +23,10 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     fiber-storage (1.0.0)
-    graphql (2.4.8)
+    graphql (2.4.14)
       base64
       fiber-storage
+      logger
     hashdiff (1.1.2)
     io-console (0.8.0)
     irb (1.14.3)

--- a/graphql-hive.gemspec
+++ b/graphql-hive.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
 
-  spec.add_dependency "graphql", ">= 2.3", "< 3"
+  spec.add_dependency "graphql", ">= 2.4.12", "< 3"
   spec.add_dependency "logger"
 end

--- a/lib/graphql-hive/report.rb
+++ b/lib/graphql-hive/report.rb
@@ -52,7 +52,8 @@ module GraphQLHive
         analyzer = GraphQLHive::Analyzer.new(query)
         visitor = GraphQL::Analysis::AST::Visitor.new(
           query: query,
-          analyzers: [analyzer]
+          analyzers: [analyzer],
+          timeout: nil
         )
 
         result = visitor.visit

--- a/lib/graphql-hive/version.rb
+++ b/lib/graphql-hive/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GraphQLHive
-  VERSION = "0.5.4"
+  VERSION = "0.5.5"
 
   def self.gem_version
     Gem::Version.new(VERSION)

--- a/spec/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql-hive/analyzer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "GraphQLHive::Analyzer" do
     analyzer = GraphQLHive::Analyzer.new(query)
     visitor = GraphQL::Analysis::AST::Visitor.new(
       query: query,
-      analyzers: [analyzer]
+      analyzers: [analyzer],
+      timeout: nil
     )
 
     visitor.visit


### PR DESCRIPTION
Graphl [2.4.12](https://github.com/rmosolgo/graphql-ruby/commit/04e6e1c3dde8761a145c9106ab29cd3c31dda8f8#diff-a32a19923eabf2381a04b316db4de0f7eaee164d2b5446e91716dc71b3d35da0R13-R24) add a new timeout attribute to the `Visitor` class.